### PR TITLE
Add python link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 Hint: click on the name to be taken to the appropriate wrapper code
 
+* [python](wrappers/python)
 * [MATLAB](wrappers/MATLAB)
 * [Excel](wrappers/Excel)
 * [Labview](wrappers/Labview)

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ Hint: click on the name to be taken to the appropriate wrapper code
 Users are welcome to contribute wrappers to other languages and environments, and efforts are underway to make the full REFPROP API accessible to many more languages through the use of SWIG wrappers
 
 Pull requests welcome!  You will get credit for your contribution, and the thanks of the REFPROP user community.
+


### PR DESCRIPTION
Add a link to the python wrapper on the main readme.