### PR TITLE
Comment rework and some variable name standardization

### DIFF
--- a/wrappers/Csharp/IRefProp/IRefProp64.cs
+++ b/wrappers/Csharp/IRefProp/IRefProp64.cs
@@ -247,5 +247,24 @@ namespace MCS
            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] double[] x,  // => composition array
            ref double wm     //
         );
+
+
+        /* Provides fluid constants for specified component */
+        [DllImport(@"C:\Program Files (x86)\REFPROP\REFPRP64.dll", CharSet = CharSet.Ansi)]
+        public static extern void INFOdll
+            (
+            ref long icomp, // Component number in mixture. 1 for pure fluid
+            ref double wmm, // molecular weight [g/mol]
+            ref double ttrp, // triple point temperature [K]
+            ref double tnbpt, // normal boiling point temperature [K]
+            ref double tc, // critical temperature [K]
+            ref double pc, // critical pressure [kPa]
+            ref double Dc, // critical density [mol/L]
+            ref double Zc, // compressibility at critical point [pc/(Rgas*Tc*Dc)]
+            ref double acf, // acentric factor [dimensionless]
+            ref double dip, // dipole moment [debeye]
+            ref double Rgas // gas constant [J/mol-K]
+            );
+
     }
 }


### PR DESCRIPTION
A lot of the comments seemed to be auto-generated by some documentation tool. I removed those and replaced them with some explanations taken straight out of the REFPROP manual itself. No actual code changes in this one.

Multiple commits because forks are not treated like branches, leading to some duplicate commits having to sort themselves out in a manual merge.