### PR TITLE
Osx excel

### DIFF
--- a/wrappers/Excel/README.md
+++ b/wrappers/Excel/README.md
@@ -33,11 +33,11 @@ For OSX with Office 365: (The following has only been tested with REFPROP 9.1)
     Private Const FluidsDirectory As String = "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/refprop/FLUIDS/"
     Private Const MixturesDirectory As String = "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/refprop/MIXTURES/"
     ```
-    Replace all occurances of "REFPRP64.DLL" with  
+    Replace all occurrences of "REFPRP64.DLL" with  
     
     "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/refprop/librefprop.dylib"
     
-    Replace all occurances of "$USER" with your username
+    Replace all occurrences of "$USER" with your username
     
 9.  Save and all REFPROP functions should be accessible in Excel
 

--- a/wrappers/Excel/README.md
+++ b/wrappers/Excel/README.md
@@ -14,11 +14,11 @@ Installation
 
 For OSX with Office 365: (The following has only been tested with REFPROP 9.1)
 
-1.  Build librefprop.dylib following instructions on https://github.com/usnistgov/REFPROP-cmake
+1.  Build "librefprop.dylib" following instructions on https://github.com/usnistgov/REFPROP-cmake
 2.  Create a folder named "refprop" in "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/" replacing $USER with your username
 3.  Copy your Refprop FLUIDS and MIXTURES folders (make sure they are capitalized) into the refprop folder just created
-4.  Copy the librefprop.dylib created in Step 1 into the refprop folder
-5.  Download REFPRP91.XLA and move file to "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/", replacing $USER with your username
+4.  Copy the "librefprop.dylib" created in Step 1 into the refprop folder
+5.  Download "REFPRP91.XLA" and move file to "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/", replacing $USER with your username
 6.  Open Excel, select Developer tab, click on 'Excel Add-ins'. Click 'Browse' and navigate to "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/REFPRP91.XLA"; select file and click 'Open'. Make sure the box for 'Refprp91' is checked.
 7.  Open Visual Basic editor (top left icon inside Developer tab). Inside the project box (upper left) double-click 'Refprop91Code' under REFPROP/Modules.
 8.  Perform the following code edits:  
@@ -40,6 +40,7 @@ For OSX with Office 365: (The following has only been tested with REFPROP 9.1)
     Replace all occurances of "$USER" with your username
     
 9.  Save and all REFPROP functions should be accessible in Excel
+
 
 The following outlines the procedure for using REFPROP within any spreadsheet in Office 2007 or 2010:
 

--- a/wrappers/Excel/README.md
+++ b/wrappers/Excel/README.md
@@ -12,6 +12,35 @@ To download the above files (XLS and XLA), click on the file, then the download 
 Installation
 ------------
 
+For OSX with Office 365: (The following has only been tested with REFPROP 9.1)
+
+1.  Build librefprop.dylib following instructions on https://github.com/usnistgov/REFPROP-cmake
+2.  Create a folder named "refprop" in "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/" replacing $USER with your username
+3.  Copy your Refprop FLUIDS and MIXTURES folders (make sure they are capitalized) into the refprop folder just created
+4.  Copy the librefprop.dylib created in Step 1 into the refprop folder
+5.  Download REFPRP91.XLA and move file to "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/", replacing $USER with your username
+6.  Open Excel, select Developer tab, click on 'Excel Add-ins'. Click 'Browse' and navigate to "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/REFPRP91.XLA"; select file and click 'Open'. Make sure the box for 'Refprp91' is checked.
+7.  Open Visual Basic editor (top left icon inside Developer tab). Inside the project box (upper left) double-click 'Refprop91Code' under REFPROP/Modules.
+8.  Perform the following code edits:  
+    
+    Replace
+    ```
+    Private Const FluidsDirectory As String = "fluids\"
+    Private Const MixturesDirectory As String = "mixtures\"
+    ```
+    with
+    ```
+    Private Const FluidsDirectory As String = "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/refprop/FLUIDS/"
+    Private Const MixturesDirectory As String = "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/refprop/MIXTURES/"
+    ```
+    Replace all occurances of "REFPRP64.DLL" with  
+    
+    "/Users/$USER/Library/Group Containers/UBF8T346G9.Office/refprop/librefprop.dylib"
+    
+    Replace all occurances of "$USER" with your username
+    
+9.  Save and all REFPROP functions should be accessible in Excel
+
 The following outlines the procedure for using REFPROP within any spreadsheet in Office 2007 or 2010:
 
 1.  Open REFPROP.xls and save it as an add-in, REFPROP.xla or REFPROP.xlam, in the main REFPROP folder, C:\Program Files\REFPROP.


### PR DESCRIPTION
Edited the readme to include instructions for getting REFPROP to work in Excel on OSX. I did not add steps to change the function declaration structure
```
If VBA7
   If Win64
```
to
```
If VBA7
  If Mac
```
as is done in CoolProp's code, because it worked fine on my machine without modifying it. I'll let the professionals determine the best path on that :)