### PR TITLE
Fix all TP functions and reverse TH functions

### DIFF
--- a/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.vcxproj
+++ b/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.vcxproj
@@ -53,7 +53,7 @@
     <ClInclude Include="..\includes\rp_kft.h" />
     <ClInclude Include="..\includes\rp_kgp.h" />
     <ClInclude Include="..\includes\rp_kgt.h" />
-    <ClInclude Include="..\includes\rp_ktp.h" />
+    <ClInclude Include="..\includes\rp_LIMITS.h" />
     <ClInclude Include="..\includes\rp_mufp.h" />
     <ClInclude Include="..\includes\rp_muft.h" />
     <ClInclude Include="..\includes\rp_mugp.h" />
@@ -91,6 +91,7 @@
     <ClInclude Include="..\includes\rp_tcrit.h" />
     <ClInclude Include="..\includes\rp_ths.h" />
     <ClInclude Include="..\includes\rp_tmax.h" />
+    <ClInclude Include="..\includes\rp_tmin.h" />
     <ClInclude Include="..\includes\rp_tph.h" />
     <ClInclude Include="..\includes\rp_tps.h" />
     <ClInclude Include="..\includes\rp_tsatp.h" />
@@ -198,20 +199,20 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\..\..\externals\fmtlib;..\..\..\externals\REFPROP-headers;..\includes;C:\Program Files\PTC\Mathcad Prime 6.0.0.0\Custom Functions;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\externals\fmtlib;..\..\..\externals\REFPROP-headers;..\includes;C:\Program Files\PTC\Mathcad Prime 8.0.0.0\Custom Functions;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files\PTC\Mathcad Prime 6.0.0.0\Custom Functions;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\PTC\Mathcad Prime 8.0.0.0\Custom Functions;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <EntryPointSymbol>DllEntryPoint</EntryPointSymbol>
       <AdditionalDependencies>mcaduser.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(TargetPath)" "C:\Program Files\PTC\Mathcad Prime 6.0.0.0\Custom Functions" /rqky</Command>
+      <Command>xcopy "$(TargetPath)" "C:\Program Files\PTC\Mathcad Prime 8.0.0.0\Custom Functions" /rqky</Command>
     </PostBuildEvent>
     <PostBuildEvent>
-      <Message>Copy the DLL to the "PTC\Mathcad Prime 6.0.0.0\Custom Functions" folder</Message>
+      <Message>Copy the DLL to the "PTC\Mathcad Prime 8.0.0.0\Custom Functions" folder</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/wrappers/Mathcad/includes/rp_LIMITS.h
+++ b/wrappers/Mathcad/includes/rp_LIMITS.h
@@ -1,0 +1,64 @@
+LRESULT rp_LIMITS(
+    LPCOMPLEXARRAY      ret,
+    LPCMCSTRING       fluid,
+    LPCMCSTRING       htype)
+{
+    double Tminx, Tmaxx, Dmaxx, Pmaxx;                          // Limits variables
+    int ierr = 0;
+    unsigned int rows = 4, cols = 1;
+
+    ierr = cSetup(fluid->str);
+    if (ierr != 0)
+        return MAKELRESULT(ierr, 1);
+
+    std::string strType = upper(htype->str);  // Extract to std::string for each compare
+
+    if ((strType != "EOS") && (strType != "ETA") && (strType != "TCX"))
+        return MAKELRESULT(INVALID_MODEL, 2);
+
+    // Get Limits for requested model
+    LIMITSdll(&strType[0], &x[0], &Tminx, &Tmaxx, &Dmaxx, &Pmaxx, lengthofreference);
+
+    //allocate memory for the Limit values
+    if (!MathcadArrayAllocate(
+        ret,
+        rows,
+        cols,
+        TRUE,
+        FALSE))
+    {
+        // if allocation is not successful, return with the appropriate error code
+        return MAKELRESULT(INSUFFICIENT_MEMORY, 1);
+    }
+
+    if (isUserInterrupted())
+    {
+        // if use has interrupted -- free the allocated memory
+        MathcadArrayFree(ret);
+        // and return with an appropriate error code
+        return MAKELRESULT(INTERRUPTED, 1);
+    }
+
+    // Assign return array elements
+	ret->hReal[0][0] = Tminx;         // Returned in K
+    ret->hReal[0][1] = Tmaxx;         // Returned in K
+    ret->hReal[0][2] = Dmaxx * wmm;   // Convert from mol/L to kg/m³
+    ret->hReal[0][3] = Pmaxx / 1000;  // Convert from kPa to MPa
+
+    return 0;               // return 0 to indicate there was no error
+            
+}           
+
+FUNCTIONINFO    rp_limits = 
+{ 
+    (char *)("rp_limits"),              // Name by which mathcad will recognize the function
+    (char *)("fluid,htype"),            // rp_limits will be called as rp_limits(fluid,htype)
+    (char *)("Returns limits Tmin [K], Tmax [K], Dmax [kg/m°], Pmax [MPa] of the fluid model in htype as an array."),
+										// description of rp_limits(fluid,htype)
+    (LPCFUNCTION)rp_LIMITS,             // pointer to the executable code
+    COMPLEX_ARRAY,                      // the return type is a 1x4 complex array
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // String argument
+	  MC_STRING }                       // String argument
+};
+    

--- a/wrappers/Mathcad/includes/rp_cptp.h
+++ b/wrappers/Mathcad/includes/rp_cptp.h
@@ -5,9 +5,10 @@ LRESULT rp_Cptp(
     LPCCOMPLEXSCALAR      p   )
 {
 	double tval,pval,Dval;
-    double Dl, Dv, Q, U, H, S, Cv, Cp, W;
+    double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
-	int ierr = 0;
+    int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
 	ierr = cSetup(fluid->str);
@@ -24,22 +25,61 @@ LRESULT rp_Cptp(
     if( p->imag != 0.0 )
 		return MAKELRESULT(MUST_BE_REAL,3);
 	else
-		pval = p->real * 1000.0;
+		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
-    TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
-        &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
-        &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
-        &ierr, herr, errormessagelength);   // error code and string
+    //===============================================================================
+    // Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+    // Get critical pressure
+    if (ncomp > 1)
+    {
+        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr != 0)
+        {
+            return MAKELRESULT(UNCONVERGED, 2);
+        }
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
 
-    if (ierr > 0)
+    // If above critical pressure (Liquid) use TPRHO instead of TPFLSH
+    // TODO: Not sure what happens if above Tcrit.  Is this vapor or liquid?  Which flag to set?
+    //       May need to adjust initial guess depending on location.
+    //       Extend this logic to all other functions of TP once it is working.
+    if (tval > tc) kph = 2;
+    if (pval > pc) kph = 1;
+    if ((pval > pc) || (tval > tc))
+    {
+        // Get single-phase density
+        TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
+        // Have density, now call THERM to get Enthalpy
+        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
+    }
+    else
+    {
+        TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
+            &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
+            &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
+            &ierr, herr, errormessagelength);   // error code and string
+    }
+    //===============================================================================
+    // End Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+
+    if (ierr > 0) {
         if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13))
             return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
         else if ((ierr == 4) || (ierr == 12))
             return MAKELRESULT(P_OUT_OF_RANGE, 1);  // Pressure out of bounds
+        else if (ierr == 8)
+            return MAKELRESULT(X_SUM_NONUNITY, 1);  // component and/or sum < 0 or > 1
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
+    }
 
     ret->real = Cp / wmm;   // Convert from J/mol-K to kJ/kg-K
 

--- a/wrappers/Mathcad/includes/rp_cvtp.h
+++ b/wrappers/Mathcad/includes/rp_cvtp.h
@@ -5,9 +5,10 @@ LRESULT rp_Cvtp(
     LPCCOMPLEXSCALAR      p   )
 {
 	double tval,pval,Dval;
-    double Dl, Dv, Q, U, H, S, Cv, Cp, W;
+    double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
-	int ierr = 0;
+    int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
 	ierr = cSetup(fluid->str);
@@ -24,22 +25,61 @@ LRESULT rp_Cvtp(
     if( p->imag != 0.0 )
 		return MAKELRESULT(MUST_BE_REAL,3);
 	else
-		pval = p->real * 1000.0;
+		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
-    TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
-        &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
-        &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
-        &ierr, herr, errormessagelength);   // error code and string
+    //===============================================================================
+    // Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+    // Get critical pressure
+    if (ncomp > 1)
+    {
+        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr != 0)
+        {
+            return MAKELRESULT(UNCONVERGED, 2);
+        }
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
 
-    if (ierr > 0)
+    // If above critical pressure (Liquid) use TPRHO instead of TPFLSH
+    // TODO: Not sure what happens if above Tcrit.  Is this vapor or liquid?  Which flag to set?
+    //       May need to adjust initial guess depending on location.
+    //       Extend this logic to all other functions of TP once it is working.
+    if (tval > tc) kph = 2;
+    if (pval > pc) kph = 1;
+    if ((pval > pc) || (tval > tc))
+    {
+        // Get single-phase density
+        TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
+        // Have density, now call THERM to get Enthalpy
+        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
+    }
+    else
+    {
+        TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
+            &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
+            &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
+            &ierr, herr, errormessagelength);   // error code and string
+    }
+    //===============================================================================
+    // End Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+
+    if (ierr > 0) {
         if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13))
             return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
         else if ((ierr == 4) || (ierr == 12))
             return MAKELRESULT(P_OUT_OF_RANGE, 1);  // Pressure out of bounds
+        else if (ierr == 8)
+            return MAKELRESULT(X_SUM_NONUNITY, 1);  // component and/or sum < 0 or > 1
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
+    }
 
 	ret->real = Cv / wmm;   // Convert from J/mol-K to kJ/kg-K
 

--- a/wrappers/Mathcad/includes/rp_extrapolate.h
+++ b/wrappers/Mathcad/includes/rp_extrapolate.h
@@ -12,7 +12,7 @@ LRESULT rp_Extrap(
     if ((iset == 0) || (iset = 1))
         extr = iset;
     else
-        return MAKELRESULT(INVALID_FLAG, 1);
+        return MAKELRESULT(BAD_INPUT, 1);
 
 	// allocate memory for return string
 	pdest = MathcadAllocate(23);

--- a/wrappers/Mathcad/includes/rp_hps.h
+++ b/wrappers/Mathcad/includes/rp_hps.h
@@ -37,7 +37,7 @@ LRESULT rp_Hps(
 		return MAKELRESULT(UNCONVERGED,1);
 
 	if (pval < pc) // *** Below the Critical Point ***
-	{
+    {
 		// Below the critical pressure
 		SATPdll(&pval, x, &kph, &tsat, &rhol, &rhov, xliq, xvap, &ierr, herr, errormessagelength);
 		if (ierr != 0)

--- a/wrappers/Mathcad/includes/rp_htp.h
+++ b/wrappers/Mathcad/includes/rp_htp.h
@@ -5,9 +5,10 @@ LRESULT rp_Htp(
     LPCCOMPLEXSCALAR      p   )
 {
 	double tval,pval,Dval;
-    double Dl, Dv, Q, U, H, S, Cv, Cp, W;
+    double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
-	int ierr = 0;
+    int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
 	ierr = cSetup(fluid->str);
@@ -24,22 +25,66 @@ LRESULT rp_Htp(
     if( p->imag != 0.0 )
 		return MAKELRESULT(MUST_BE_REAL,3);
 	else
-		pval = p->real * 1000.0;
+		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
-    TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
-        &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
-        &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
-        &ierr, herr, errormessagelength);   // error code and string
+    //===============================================================================
+    // Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+    // Get critical pressure
+    if (ncomp > 1)
+    {
+        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr != 0)
+        {
+            return MAKELRESULT(UNCONVERGED, 2);
+        }
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
 
-    if (ierr > 0)
+    // If above critical pressure (Liquid) use TPRHO instead of TPFLSH
+    // TODO: Not sure what happens if above Tcrit.  Is this vapor or liquid?  Which flag to set?
+    //       May need to adjust initial guess depending on location.
+    //       Extend this logic to all other functions of TP once it is working.
+    if (tval > tc) kph = 2;
+    if (pval > pc) kph = 1;
+    if ((pval > pc) || (tval > tc))
+    {
+        // Get single-phase density
+        TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
+        // Have density, now call THERM to get Enthalpy
+        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
+    }
+    else
+    {
+        TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
+            &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
+            &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
+            &ierr, herr, errormessagelength);   // error code and string
+    }
+    //===============================================================================
+    // End Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+
+    if (ierr > 0) {
+        // Use this pop-up window for debugging if needed
+        //===============================================================================
+        //msg = format("\n  ierr: %d",ierr);
+        //MessageBox(hwndDlg, msg.c_str(), "NIST RefProp Add-In", 0);
+        //===============================================================================
         if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13))
             return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
         else if ((ierr == 4) || (ierr == 12))
             return MAKELRESULT(P_OUT_OF_RANGE, 1);  // Pressure out of bounds
+        else if (ierr == 8)
+            return MAKELRESULT(X_SUM_NONUNITY, 1);  // component and/or sum < 0 or > 1
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
+    }
 
 	ret->real = H / wmm;   // Convert from J/mol to kJ/kg
 

--- a/wrappers/Mathcad/includes/rp_ktp.h
+++ b/wrappers/Mathcad/includes/rp_ktp.h
@@ -4,12 +4,15 @@ LRESULT rp_Ktp(
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      p)
 {
-    double mu, cond;
     double tval, pval, Dval;
-    double Dl, Dv, Q, U, H, S, Cv, Cp, W;
+    double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double TminK,TmaxK,DmaxK,PmaxK;                          // TC Limits
+    double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
+    double mu, cond;
     double xl[20], xv[20];
-    int ierr;
+    int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
+    char htype[] = "TCX";
 
     ierr = cSetup(fluid->str);
     if (ierr != 0)
@@ -20,27 +23,77 @@ LRESULT rp_Ktp(
     else
         tval = t->real;
 
-    if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
-
     if (p->imag != 0.0)
         return MAKELRESULT(MUST_BE_REAL, 3);
     else
         pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
-    if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
+    // Get Limits for TCX model
+    LIMITSdll(htype, &x[0], &TminK, &TmaxK, &DmaxK, &PmaxK, lengthofreference);
 
-    TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
-        &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
-        &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
-        &ierr, herr, errormessagelength);   // error code and string
+    if ((tval > std::min(Tmax,TmaxK)*(1 + 0.5*extr)) ||   // if above Tmax for EOS or TCX, or
+        (tval < std::max(Tmin,TminK)))                    //    below Tmin for EOS or TCS,
+        return MAKELRESULT(T_OUT_OF_RANGE, 2);            //    throw error.
 
-    if (ierr > 0)
+    if (pval > std::min(Pmax,PmaxK)*(1 + extr))           // if above Pmax for EOS or TCX,
+        return MAKELRESULT(P_OUT_OF_RANGE, 3);            //    throw error.
+
+    //===============================================================================
+    // Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+    // Get critical pressure
+    if (ncomp > 1)
+    {
+        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr != 0)
+        {
+            return MAKELRESULT(UNCONVERGED, 2);
+        }
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
+
+    // If above critical pressure (Liquid) use TPRHO instead of TPFLSH
+    // TODO: Not sure what happens if above Tcrit.  Is this vapor or liquid?  Which flag to set?
+    //       May need to adjust initial guess depending on location.
+    //       Extend this logic to all other functions of TP once it is working.
+    if (tval > tc) kph = 2;
+    if (pval > pc) kph = 1;
+    if ((pval > pc) || (tval > tc))
+    {
+        // Get single-phase density
+        TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
+        // Have density, now call THERM to get Enthalpy
+        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
+    }
+    else
+    {
+        TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
+            &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
+            &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
+            &ierr, herr, errormessagelength);   // error code and string
+    }
+    //===============================================================================
+    // End Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+
+    if (ierr > 0) {
+        // Use this pop-up window for debugging if needed
+        //===============================================================================
+        //msg = format("\n  ierr: %d",ierr);
+        //MessageBox(hwndDlg, msg.c_str(), "NIST RefProp Add-In", 0);
+        //===============================================================================
         if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13))
             return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
         else if ((ierr == 4) || (ierr == 12))
             return MAKELRESULT(P_OUT_OF_RANGE, 3);  // Pressure out of bounds
+        else if (ierr == 8)
+            return MAKELRESULT(X_SUM_NONUNITY, 1);  // component and/or sum < 0 or > 1
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
+    }
 
     TRNPRPdll(&tval,&Dval,x,&mu,&cond,&ierr,herr,errormessagelength);
 

--- a/wrappers/Mathcad/includes/rp_pth.h
+++ b/wrappers/Mathcad/includes/rp_pth.h
@@ -10,7 +10,7 @@ LRESULT rp_Pth(
 	double pval,hval,Dval,tval,qval;
 	double rhol,rhov,xliq[20],xvap[20];
     double U, S, Cv, Cp, W;
-    double tc, pc, Dc, hvap, psat;
+    double tc, pc, Dc;        //  , hvap, psat;    // no longer needed
 	int ierr;
 	int kph = 2;
 	int kr;
@@ -38,7 +38,8 @@ LRESULT rp_Pth(
 		if ((kr<1)||(kr>2)) return MAKELRESULT(INVALID_FLAG,4); 
 	}
 
-    // Upper root not supported for T < Tc and H > Hvap.  Find Tc and check if kr == 2
+    // Upper root not supported in REFPROP 9.1 for T < Tc and H > Hvap.  Find Tc and check if kr == 2
+    /* Fixed in REFPROP 10 *** Comment this section out ****
     if (kr == 2)
     {
         CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
@@ -60,6 +61,14 @@ LRESULT rp_Pth(
                 return MAKELRESULT(NO_UPPER_ROOT, 4);
         }
     }
+    */
+
+    // REFPROP 10 Issue: Single-phase root confusion when T = Tc exactly
+    // As a workaround, adjust tval slightly if Tc passed in
+    CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+    if (ierr != 0)
+        return MAKELRESULT(UNCONVERGED, 1);
+    if (tval == tc) tval = tval + 0.0001;
 
     pval = 0.0;
 
@@ -75,10 +84,6 @@ LRESULT rp_Pth(
         else
             return MAKELRESULT(UNCONVERGED, 1);
     }
-
-	// If pval > Pmax, return error 4
-	if (pval > Pmax + extr*Pmax)
-		return MAKELRESULT(P_OUT_OF_RANGE,1);
 
 	// Otherwise...
 	ret->real = pval / 1000.0;       // Returned in MPa

--- a/wrappers/Mathcad/includes/rp_rhots.h
+++ b/wrappers/Mathcad/includes/rp_rhots.h
@@ -44,18 +44,6 @@ LRESULT rp_Rhots(
             return MAKELRESULT(UNCONVERGED, 1);
     }
 
-    // If pval > Pmax, return error 4   ( * 2.0 Pmax)
-    if (pval > Pmax + extr * Pmax)
-        return MAKELRESULT(P_OUT_OF_RANGE,1);
-
-    // If rhol != rhov, two phase saturation region,
-    // calculate mixture density lever law on 1/rho using Q
-    // Is this needed, or does REFPROP do this calculation already?
-    if (rhol != rhov)
-    {
-        Dval = 1.0 / (qval*(1.0/rhov) + (1-qval)*(1.0/rhol));
-    }
-
     ret->real = Dval * wmm;       // Returned in kg/m³
 
     return 0;               // return 0 to indicate there was no error

--- a/wrappers/Mathcad/includes/rp_stp.h
+++ b/wrappers/Mathcad/includes/rp_stp.h
@@ -5,9 +5,10 @@ LRESULT rp_Stp(
     LPCCOMPLEXSCALAR      p   )
 {
 	double tval,pval,Dval;
-    double Dl, Dv, Q, U, H, S, Cv, Cp, W;
+    double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
-	int ierr = 0;
+    int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
 	ierr = cSetup(fluid->str);
@@ -24,22 +25,61 @@ LRESULT rp_Stp(
     if( p->imag != 0.0 )
 		return MAKELRESULT(MUST_BE_REAL,3);
 	else
-		pval = p->real * 1000.0;
+		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
-    TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
-        &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
-        &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
-        &ierr, herr, errormessagelength);   // error code and string
+    //===============================================================================
+    // Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+    // Get critical pressure
+    if (ncomp > 1)
+    {
+        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr != 0)
+        {
+            return MAKELRESULT(UNCONVERGED, 2);
+        }
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
 
-    if (ierr > 0)
+    // If above critical pressure (Liquid) use TPRHO instead of TPFLSH
+    // TODO: Not sure what happens if above Tcrit.  Is this vapor or liquid?  Which flag to set?
+    //       May need to adjust initial guess depending on location.
+    //       Extend this logic to all other functions of TP once it is working.
+    if (tval > tc) kph = 2;
+    if (pval > pc) kph = 1;
+    if ((pval > pc) || (tval > tc))
+    {
+        // Get single-phase density
+        TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
+        // Have density, now call THERM to get Enthalpy
+        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
+    }
+    else
+    {
+        TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
+            &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
+            &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
+            &ierr, herr, errormessagelength);   // error code and string
+    }
+    //===============================================================================
+    // End Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+
+    if (ierr > 0) {
         if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13))
             return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
         else if ((ierr == 4) || (ierr == 12))
             return MAKELRESULT(P_OUT_OF_RANGE, 1);  // Pressure out of bounds
+        else if (ierr == 8)
+            return MAKELRESULT(X_SUM_NONUNITY, 1);  // component and/or sum < 0 or > 1
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
+    }
 
 	ret->real = S/wmm;   // Convert from J/mol-K to kJ/kg-K
 

--- a/wrappers/Mathcad/includes/rp_tmin.h
+++ b/wrappers/Mathcad/includes/rp_tmin.h
@@ -1,0 +1,27 @@
+LRESULT rp_Tmin(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid   )
+{
+	int ierr = 0;
+
+	ierr = cSetup(fluid->str);
+	if (ierr != 0 )
+		return MAKELRESULT(ierr,1);
+
+    ret->real = Tmin;
+
+    return 0;               // return 0 to indicate there was no error
+            
+}           
+
+    FUNCTIONINFO    rp_tmin = 
+{ 
+    (char *)("rp_tmin"),               // Name by which Mathcad will recognize the function
+    (char *)("fluid"),                 // rp_tmax will be called as rp_tmin(fluid)
+    (char *)("Returns minimum temperature [K] of the fluid/mixture specified"),
+									   // description of rp_tmax(fluid)
+    (LPCFUNCTION)rp_Tmin,              // pointer to the executable code
+    COMPLEX_SCALAR,                    // the return type is a complex scalar
+    1,                                 // the function takes on 1 argument
+    { MC_STRING }                      // argument is an MC_STRING
+};

--- a/wrappers/Mathcad/includes/rp_utp.h
+++ b/wrappers/Mathcad/includes/rp_utp.h
@@ -5,9 +5,10 @@ LRESULT rp_Utp(
     LPCCOMPLEXSCALAR      p   )
 {
 	double tval,pval,Dval;
-    double Dl, Dv, Q, U, H, S, Cv, Cp, W;
+    double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
-	int ierr = 0;
+    int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
 	ierr = cSetup(fluid->str);
@@ -24,22 +25,66 @@ LRESULT rp_Utp(
     if( p->imag != 0.0 )
 		return MAKELRESULT(MUST_BE_REAL,3);
 	else
-		pval = p->real * 1000.0;
+		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
-    TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
-        &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
-        &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
-        &ierr, herr, errormessagelength);   // error code and string
+    //===============================================================================
+    // Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+    // Get critical pressure
+    if (ncomp > 1)
+    {
+        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr != 0)
+        {
+            return MAKELRESULT(UNCONVERGED, 2);
+        }
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
 
-    if (ierr > 0)
+    // If above critical pressure (Liquid) use TPRHO instead of TPFLSH
+    // TODO: Not sure what happens if above Tcrit.  Is this vapor or liquid?  Which flag to set?
+    //       May need to adjust initial guess depending on location.
+    //       Extend this logic to all other functions of TP once it is working.
+    if (tval > tc) kph = 2;
+    if (pval > pc) kph = 1;
+    if ((pval > pc) || (tval > tc))
+    {
+        // Get single-phase density
+        TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
+        // Have density, now call THERM to get Enthalpy
+        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
+    }
+    else
+    {
+        TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
+            &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
+            &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
+            &ierr, herr, errormessagelength);   // error code and string
+    }
+    //===============================================================================
+    // End Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+
+    if (ierr > 0) {
+        // Use this pop-up window for debugging if needed
+        //===============================================================================
+        //msg = format("\n  ierr: %d",ierr);
+        //MessageBox(hwndDlg, msg.c_str(), "NIST RefProp Add-In", 0);
+        //===============================================================================
         if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13))
             return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
         else if ((ierr == 4) || (ierr == 12))
             return MAKELRESULT(P_OUT_OF_RANGE, 1);  // Pressure out of bounds
+        else if (ierr == 8)
+            return MAKELRESULT(X_SUM_NONUNITY, 1);  // component and/or sum < 0 or > 1
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
+    }
 
 	ret->real = U/wmm;   // Convert from J/mol to kJ/kg
 

--- a/wrappers/Mathcad/includes/rp_wtp.h
+++ b/wrappers/Mathcad/includes/rp_wtp.h
@@ -5,9 +5,10 @@ LRESULT rp_Wtp(
     LPCCOMPLEXSCALAR      p   )
 {
 	double tval,pval,Dval;
-    double Dl, Dv, Q, U, H, S, Cv, Cp, W;
+    double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
-	int ierr = 0;
+    int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
 	ierr = cSetup(fluid->str);
@@ -24,22 +25,61 @@ LRESULT rp_Wtp(
     if( p->imag != 0.0 )
 		return MAKELRESULT(MUST_BE_REAL,3);
 	else
-		pval = p->real * 1000.0;
+		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
-    TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
-        &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
-        &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
-        &ierr, herr, errormessagelength);   // error code and string
+    //===============================================================================
+    // Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+    // Get critical pressure
+    if (ncomp > 1)
+    {
+        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr != 0)
+        {
+            return MAKELRESULT(UNCONVERGED, 2);
+        }
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
 
-    if (ierr > 0)
+    // If above critical pressure (Liquid) use TPRHO instead of TPFLSH
+    // TODO: Not sure what happens if above Tcrit.  Is this vapor or liquid?  Which flag to set?
+    //       May need to adjust initial guess depending on location.
+    //       Extend this logic to all other functions of TP once it is working.
+    if (tval > tc) kph = 2;
+    if (pval > pc) kph = 1;
+    if ((pval > pc) || (tval > tc))
+    {
+        // Get single-phase density
+        TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
+        // Have density, now call THERM to get Enthalpy
+        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
+    }
+    else
+    {
+        TPFLSHdll(&tval, &pval, &x[0], &Dval,   // [K], [kPa], [mol/L]
+            &Dl, &Dv, &xl[0], &xv[0],           // Saturation terms
+            &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
+            &ierr, herr, errormessagelength);   // error code and string
+    }
+    //===============================================================================
+    // End Mod 6/2/2022 to get all the way up to Pmax
+    //===============================================================================
+
+    if (ierr > 0) {
         if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13))
             return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
         else if ((ierr == 4) || (ierr == 12))
             return MAKELRESULT(P_OUT_OF_RANGE, 1);  // Pressure out of bounds
+        else if (ierr == 8)
+            return MAKELRESULT(X_SUM_NONUNITY, 1);  // component and/or sum < 0 or > 1
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
+    }
 
 	ret->real = W;
 

--- a/wrappers/Mathcad/includes/setup.h
+++ b/wrappers/Mathcad/includes/setup.h
@@ -117,7 +117,7 @@ int cSetup(std::string strFluid)
         strcpy(MixName, "N/A");
         MixFileLast = "";
         // convert std::string to c-style string for DLL call
-        std::copy(fluid_string.begin(), fluid_string.end(), hfld);    // Copy string fluidPath into c_str mypath. 
+        std::copy(fluid_string.begin(), fluid_string.end(), hfld);    // Copy string fluidPath into c_str hfld. 
         // hfld[fluid_string.size()] = '\0';                          // Append with a null character (not sure if needed)
         // Pad the fluid string all the way to 10k characters with spaces to deal with string parsing bug in REFPROP in SETUPdll
         for (int j = static_cast<int>(fluid_string.size()); j < componentstringlength; ++j) {
@@ -214,7 +214,7 @@ int cSetup(std::string strFluid)
         }
         // convert std::string to c-style string for DLL call
         char hfld[10000];                                            // Initialize char array hfld
-        std::copy(strFluid.begin(), strFluid.end(), hfld);           // Copy string fluidPath into c_str mypath. 
+        std::copy(strFluid.begin(), strFluid.end(), hfld);           // Copy string fluidPath into c_str hfld. 
         hfld[strFluid.size()] = '\0';                                // Append with a null character (not sure if needed)
 
         SETUPdll(&ncomp,hfld,hhmx,href,&ierr,herr,

--- a/wrappers/Mathcad/src/Refprop.cpp
+++ b/wrappers/Mathcad/src/Refprop.cpp
@@ -53,17 +53,17 @@ enum { MC_STRING = STRING }; // Substitute enumeration variable MC_STRING for ST
 #include <fstream>
 
 // RefProp Mathcad Add-in Version
-std::string rpVersion = "2.0";       // Mathcad Add-in version number
+std::string rpVersion = "2.0.1";       // Mathcad Add-in version number
 
 // Setup Dialog Window for debugging
 HWND hwndDlg;  // Dialog handle for pop-up message boxes
 
 enum EC {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,                  // Mathcad Error Codes
          T_OUT_OF_RANGE, P_OUT_OF_RANGE, SATURATED,                           // Refprop Error Codes
-         FLUID_NOT_FOUND, NO_MIX, UNCONVERGED,
+         FLUID_NOT_FOUND, NO_MIX, UNCONVERGED,INVALID_MODEL,
          BAD_COMPONENT, NO_TRANSPORT, INFINITE_K,
          NO_SURFTEN, H_OUT_OF_RANGE, S_OUT_OF_RANGE,
-         D_OUT_OF_RANGE, INVALID_FLAG, X_SUM_NONUNITY,
+         D_OUT_OF_RANGE, BAD_INPUT, INVALID_FLAG, X_SUM_NONUNITY,
          NO_UPPER_ROOT, TOO_MANY_COMPONENTS, BAD_MIX_STRING,
          BAD_MOLE_FRACTION, INDIV_COMPONENT, UNKNOWN,
          NUMBER_OF_ERRORS};                                                   // Dummy code for Error Count
@@ -81,6 +81,7 @@ char * RPErrorMessageTable[NUMBER_OF_ERRORS] =
     (char *)("Fluid/Mixture not found"),                    //  FLUID_NOT_FOUND
     (char *)("Pure Fluids or Predefined Mixtures Only!"),   //  NO_MIX
     (char *)("Algorithm did not converge"),                 //  UNCONVERGED
+    (char *)("Invalid model; must be \"EOS\". \"ETA\", or \"TCX\""),  //  INVALID_MODEL
     (char *)("Undefined Component Number"),                 //  BAD_COMPONENT
     (char *)("No transport equations for this fluid"),      //  NO_TRANSPORTPORT
     (char *)("At critical point; k is infinite"),           //  INFINITE_K
@@ -88,9 +89,10 @@ char * RPErrorMessageTable[NUMBER_OF_ERRORS] =
     (char *)("Enthalpy out of range"),                      //  H_OUT_OF_RANGE
     (char *)("Entropy out of range"),                       //  S_OUT_OF_RANGE
     (char *)("Density out of range"),                       //  D_OUT_OF_RANGE
-    (char *)("Invalid Input; Must be 0 or 1"),              //  INVALID_FLAG
+    (char *)("Invalid Input; Must be 0 or 1"),              //  BAD_INPUT
+    (char *)("Invalid Phase Flag; Must be 1 or 2"),         //  INVALID_FLAG
     (char *)("Mixture fractions don't sum to unity"),       //  X_SUM_NONUNITY
-    (char *)("Upper root not supported when T < Tc"),       //  NO_UPPER_ROOT
+    (char *)("Upper root not supported when T < Tc"),       //  NO_UPPER_ROOT - no longer used
     (char *)("Too many components. Max is 20."),            //  TOO_MANY_COMPONENTS
     (char *)("Bad mixture string format: c1[mf1]&c2[mf2]...&cX[mfX]"),   // BAD_MIX_STRING
     (char *)("Mole fraction can't be converted"),           //  BAD_MOLE_FRACTION
@@ -130,6 +132,7 @@ char MixName[namelengthlong+1];       // Mixture Name from loaded mixture file.
 #include "rp_wmol.h"
 #include "rp_rgas.h"
 #include "rp_tmax.h"
+#include "rp_tmin.h"
 #include "rp_pmax.h"
 #include "rp_rhomax.h"
 #include "rp_ttrip.h"
@@ -137,6 +140,7 @@ char MixName[namelengthlong+1];       // Mixture Name from loaded mixture file.
 #include "rp_rhocrit.h"
 #include "rp_ptrip.h"
 #include "rp_pcrit.h"
+#include "rp_LIMITS.h"
 // Saturation Curve Function headers
 #include "rp_tsatp.h"
 #include "rp_psatt.h"
@@ -338,10 +342,16 @@ extern "C" BOOL WINAPI DllEntryPoint (HINSTANCE hDLL, DWORD dwReason, LPVOID lpR
         if ( CreateUserFunction( hDLL, &rp_tmax ) == NULL )
             break;
 
+        if ( CreateUserFunction( hDLL, &rp_tmin ) == NULL )
+            break;
+
         if ( CreateUserFunction( hDLL, &rp_rhomax ) == NULL )
             break;
 
         if ( CreateUserFunction( hDLL, &rp_pmax ) == NULL )
+            break;
+
+        if ( CreateUserFunction( hDLL, &rp_limits) == NULL)
             break;
 
         // Saturation Curve Definition


### PR DESCRIPTION
### Description of the Change

Fixes two issues that were occurring in the Mathcad wrapper interface:

1. **Full-range TP Functions:** T-P state function calls did not return values up to Tmax and Pmax for the fluid and returned convergence errors much beyond Tcrit and Pcrit.  Modified these functions to only rely on `TPFLSHdll` when below critical point and use the single-phase `TPFL1dll` call when clearly in single phase region.
2. **Dual-valued Reverse Lookups Failing:** T-H reverse functions were not correctly returning dual roots.  Coding still existed to work around  a REFPROP9.x issue (see: #138).  This coding is not needed in REFPROP 10 and caused invalid return values, so was removed to return the full range of dual roots correctly from `THFLASHdll` calls.  Also provided workaround when T is exactly equal to Tcrit, already reported (see:  #462), but providing a very slight offset above Tcrit.
3. **New function - rp_tmin:** Corresponds to already implemented `rp_tmax` and returns the minimum temperature for the fluid (typically liquid triple point temperature).
3. **New function - rp_limit:** Even though the wrapper automatically checks and stores "EOS" limits when a new fluid is loaded, a direct call to `LIMITSdll` so that the limits on the transport models (`htype` = "ETA" and `htype` = "TCX") for the loaded fluid.  This function was needed to perform full-range verification for transport property functions and may be generally useful.
4. **Mathcad Prime Project Updated:** Now uses Mathcad Prime 8.0 directories for compilation.

### Benefits

Improved performance of the Mathcad wrapper functions including,

1. Mathcad TP state-point functions (`rp_htp`, `rp_stp`, `rp_rhotp`, etc.) all now return values up to the extrapolation limits of 1.5 x Tmax and 2.0 x Pmax without throwing convergence errors.

2. Mathcad functions of TH (`rp_pth`, `rp_sth`, and `rp_rhoth`) all now correctly return the lower and upper roots of the dual valued results based on the passed parameter, `kr` = 1 and `kr` = 2, respectively in REFPROP 10.

3. Mathcad function `rp_limits` is implemented to make a direct call to `LIMITSdll` for any of the three property models.  The limit values are returned in a single array to Mathcad, which can split them out to separate variables with units.  An example is shown here:
![image](https://user-images.githubusercontent.com/17114032/175605278-73f38ae8-e598-46ae-9e28-fe2c8a3bf3c7.png)

### Possible Drawbacks

None.  Improved range, speed, and accuracy of the applied functions.

Noticed some mixed tab/space formatting after submitting PR.  Will clean up on later PRs, cleaning up as I go.

### Verification Process

- *How did you verify that all new functionality works as expected?*  LIMITS function results compared to values returned in the REFPROP GUI and Excel wrapper.
- *How did you verify that all changed functionality works as expected?*  Full range state-point results verified by plotting over the temperature and pressure ranges from triple point to max values as returned by LIMITS (see  [Full-Range Test.pdf](https://github.com/usnistgov/REFPROP-wrappers/files/8978642/Full-Range.Test.pdf) ).  Dual-valued reverse TH functions verified by plotting over range of inputs (see [Reverse Test.pdf](https://github.com/usnistgov/REFPROP-wrappers/files/8978656/Reverse.Test.pdf) ) as well as all of the other reverse state-point functions of TS, PS, and PH.
- *How did you verify that the change has not introduced any regressions?*  Re-ran standard regressions tests used to generate the documentation and verified there were no errors.

### Applicable Issues (none)

No open issues to close.  Enhancement to function performance.