### PR TITLE
Fix Mathcad Mixture CRITPdll Calls and Search Virtual Store for Custom Functions

### DIFF
--- a/wrappers/Mathcad/buildPrime/Prime Properties.props
+++ b/wrappers/Mathcad/buildPrime/Prime Properties.props
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <Prime8InstallDir>C:\Program Files\PTC\Mathcad Prime 8.0.0.0</Prime8InstallDir>
+    <Prime7InstallDir>C:\Program Files\PTC\Mathcad Prime 7.0.0.0</Prime7InstallDir>
+    <Prime6InstallDir>C:\Program Files\PTC\Mathcad Prime 6.0.0.0</Prime6InstallDir>
+    <Prime5InstallDir>C:\Program Files\PTC\Mathcad Prime 5.0.0.0</Prime5InstallDir>
+  </PropertyGroup>
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+  <ItemGroup>
+    <BuildMacro Include="Prime8InstallDir">
+      <Value>$(Prime8InstallDir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="Prime7InstallDir">
+      <Value>$(Prime7InstallDir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="Prime6InstallDir">
+      <Value>$(Prime6InstallDir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="Prime5InstallDir">
+      <Value>$(Prime5InstallDir)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.sln
+++ b/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.sln
@@ -1,20 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PrimeREFPROPWrapper", "RefpropPrimeWrapper.vcxproj", "{4E4732DD-A158-470F-85FC-97140A676EEC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
+		Prime 6|x64 = Prime 6|x64
+		Prime 7|x64 = Prime 7|x64
+		Prime 8|x64 = Prime 8|x64
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4E4732DD-A158-470F-85FC-97140A676EEC}.Debug|x64.ActiveCfg = Debug|x64
 		{4E4732DD-A158-470F-85FC-97140A676EEC}.Debug|x64.Build.0 = Debug|x64
+		{4E4732DD-A158-470F-85FC-97140A676EEC}.Prime 6|x64.ActiveCfg = Prime 6|x64
+		{4E4732DD-A158-470F-85FC-97140A676EEC}.Prime 7|x64.ActiveCfg = Prime 7|x64
+		{4E4732DD-A158-470F-85FC-97140A676EEC}.Prime 8|x64.ActiveCfg = Prime 8|x64
 		{4E4732DD-A158-470F-85FC-97140A676EEC}.Release|x64.ActiveCfg = Release|x64
-		{4E4732DD-A158-470F-85FC-97140A676EEC}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.vcxproj
+++ b/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.vcxproj
@@ -5,6 +5,30 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Prime 6|Win32">
+      <Configuration>Prime 6</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Prime 6|x64">
+      <Configuration>Prime 6</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Prime 7|Win32">
+      <Configuration>Prime 7</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Prime 7|x64">
+      <Configuration>Prime 7</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Prime 8|Win32">
+      <Configuration>Prime 8</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Prime 8|x64">
+      <Configuration>Prime 8</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -53,6 +77,7 @@
     <ClInclude Include="..\includes\rp_kft.h" />
     <ClInclude Include="..\includes\rp_kgp.h" />
     <ClInclude Include="..\includes\rp_kgt.h" />
+    <ClInclude Include="..\includes\rp_ktp.h" />
     <ClInclude Include="..\includes\rp_LIMITS.h" />
     <ClInclude Include="..\includes\rp_mufp.h" />
     <ClInclude Include="..\includes\rp_muft.h" />
@@ -131,6 +156,27 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Prime 8|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Prime 7|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Prime 6|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -144,6 +190,27 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Prime 8|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Prime 7|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Prime 6|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -151,18 +218,55 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="MathcadPropertySheet.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="MathcadPropertySheet.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Prime 8|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="MathcadPropertySheet.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Prime 7|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="MathcadPropertySheet.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Prime 6|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="MathcadPropertySheet.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="MathcadPropertySheet.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Prime Properties.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Prime 8|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Prime Properties.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Prime 7|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Prime Properties.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Prime 6|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="Prime Properties.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>Do_Not_Use-Set_x64_for_Prime</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Prime 8|Win32'">
+    <TargetName>Do_Not_Use-Set_x64_for_Prime</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Prime 7|Win32'">
+    <TargetName>Do_Not_Use-Set_x64_for_Prime</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Prime 6|Win32'">
     <TargetName>Do_Not_Use-Set_x64_for_Prime</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -213,6 +317,78 @@
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy the DLL to the "PTC\Mathcad Prime 8.0.0.0\Custom Functions" folder</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Prime 8|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\externals\fmtlib;..\..\..\externals\REFPROP-headers;..\includes;$(Prime8InstallDir)\Custom Functions;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(Prime8InstallDir)\Custom Functions;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <EntryPointSymbol>DllEntryPoint</EntryPointSymbol>
+      <AdditionalDependencies>mcaduser.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(TargetPath)" "$(Prime8InstallDir)\Custom Functions" /rqky</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copy the DLL to the "$(Prime8InstallDir)\Custom Functions" folder</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Prime 7|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\externals\fmtlib;..\..\..\externals\REFPROP-headers;..\includes;$(Prime7InstallDir)\Custom Functions;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(Prime7InstallDir)\Custom Functions;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <EntryPointSymbol>DllEntryPoint</EntryPointSymbol>
+      <AdditionalDependencies>mcaduser.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(TargetPath)" "$(Prime7InstallDir)\Custom Functions" /rqky</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copy the DLL to the "$(Prime7InstallDir)\Custom Functions" folder</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Prime 6|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\externals\fmtlib;..\..\..\externals\REFPROP-headers;..\includes;$(Prime6InstallDir)\Custom Functions;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(Prime6InstallDir)\Custom Functions;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <EntryPointSymbol>DllEntryPoint</EntryPointSymbol>
+      <AdditionalDependencies>mcaduser.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(TargetPath)" "$(Prime6InstallDir)\Custom Functions" /rqky</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copy the DLL to the "$(Prime6InstallDir)\Custom Functions" folder</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/wrappers/Mathcad/includes/rp_LIMITS.h
+++ b/wrappers/Mathcad/includes/rp_LIMITS.h
@@ -8,7 +8,7 @@ LRESULT rp_LIMITS(
     unsigned int rows = 4, cols = 1;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     std::string strType = upper(htype->str);  // Extract to std::string for each compare

--- a/wrappers/Mathcad/includes/rp_cpfp.h
+++ b/wrappers/Mathcad/includes/rp_cpfp.h
@@ -10,7 +10,7 @@ LRESULT rp_Cpfp(
     double Cv, Cp;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Cpfp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_cpft.h
+++ b/wrappers/Mathcad/includes/rp_cpft.h
@@ -10,7 +10,7 @@ LRESULT rp_Cpft(
     double Cv, Cp;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Cpft(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_cpgp.h
+++ b/wrappers/Mathcad/includes/rp_cpgp.h
@@ -10,7 +10,7 @@ LRESULT rp_Cpgp(
     double Cv, Cp;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Cpgp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_cpgt.h
+++ b/wrappers/Mathcad/includes/rp_cpgt.h
@@ -10,7 +10,7 @@ LRESULT rp_Cpgt(
 	double Cv, Cp;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Cpgt(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_cptp.h
+++ b/wrappers/Mathcad/includes/rp_cptp.h
@@ -4,28 +4,28 @@ LRESULT rp_Cptp(
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      p   )
 {
-	double tval,pval,Dval;
+    double tval,pval,Dval;
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
     double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real;
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real;
 
     if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
@@ -35,8 +35,8 @@ LRESULT rp_Cptp(
     // Get critical pressure
     if (ncomp > 1)
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr > 0)
         {
             return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -92,13 +92,13 @@ FUNCTIONINFO    rp_cptp =
     (char *)("rp_cptp"),                 // Name by which Mathcad will recognize the function
     (char *)("fluid,t,p"),              // rp_cptp will be called as rp_cptp(fluid,t,p)
     (char *)("Returns the specific heat [kJ/kg-K] given the temperature [K] and pressure [MPa]"),
-										// description of rp_cptp(fluid,t,p)
+                                        // description of rp_cptp(fluid,t,p)
     (LPCFUNCTION)rp_Cptp,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
     
     

--- a/wrappers/Mathcad/includes/rp_cvfp.h
+++ b/wrappers/Mathcad/includes/rp_cvfp.h
@@ -10,7 +10,7 @@ LRESULT rp_Cvfp(
     double Cv, Cp;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Cvfp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_cvft.h
+++ b/wrappers/Mathcad/includes/rp_cvft.h
@@ -10,7 +10,7 @@ LRESULT rp_Cvft(
     double Cv, Cp;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Cvft(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_cvgp.h
+++ b/wrappers/Mathcad/includes/rp_cvgp.h
@@ -10,7 +10,7 @@ LRESULT rp_Cvgp(
     double Cv, Cp;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Cvgp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_cvgt.h
+++ b/wrappers/Mathcad/includes/rp_cvgt.h
@@ -10,7 +10,7 @@ LRESULT rp_Cvgt(
 	double Cv, Cp;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Cvgt(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_cvtp.h
+++ b/wrappers/Mathcad/includes/rp_cvtp.h
@@ -4,28 +4,28 @@ LRESULT rp_Cvtp(
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      p   )
 {
-	double tval,pval,Dval;
+    double tval,pval,Dval;
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
     double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real;
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real;
 
     if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
@@ -35,8 +35,8 @@ LRESULT rp_Cvtp(
     // Get critical pressure
     if (ncomp > 1)
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr > 0)
         {
             return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -81,7 +81,7 @@ LRESULT rp_Cvtp(
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
     }
 
-	ret->real = Cv / wmm;   // Convert from J/mol-K to kJ/kg-K
+    ret->real = Cv / wmm;   // Convert from J/mol-K to kJ/kg-K
 
     return 0;               // return 0 to indicate there was no error
             
@@ -92,13 +92,13 @@ FUNCTIONINFO    rp_cvtp =
     (char *)("rp_cvtp"),                 // Name by which Mathcad will recognize the function
     (char *)("fluid,t,p"),              // rp_cvtp will be called as rp_cvtp(fluid,t,p)
     (char *)("Returns the isochoric specific heat [kJ/kg-K] given the temperature [K] and pressure [MPa]"),
-										// description of rp_cvtp(fluid,t,p)
+                                        // description of rp_cvtp(fluid,t,p)
     (LPCFUNCTION)rp_Cvtp,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
     
     

--- a/wrappers/Mathcad/includes/rp_cvtrho.h
+++ b/wrappers/Mathcad/includes/rp_cvtrho.h
@@ -8,7 +8,7 @@ LRESULT rp_Cvtrho(
 	int ierr;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (t->imag != 0.0)

--- a/wrappers/Mathcad/includes/rp_getcasn.h
+++ b/wrappers/Mathcad/includes/rp_getcasn.h
@@ -19,7 +19,7 @@ LRESULT rp_GetCAS(
 
     ierr = cSetup(strFluid);
 
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(FLUID_NOT_FOUND, 1);
 
     icomp = static_cast<int>(comp->real);

--- a/wrappers/Mathcad/includes/rp_getname.h
+++ b/wrappers/Mathcad/includes/rp_getname.h
@@ -18,7 +18,7 @@ LRESULT rp_Getname(
 
     ierr = cSetup(strFluid);
 
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     icomp = static_cast<int>(comp->real);

--- a/wrappers/Mathcad/includes/rp_hfp.h
+++ b/wrappers/Mathcad/includes/rp_hfp.h
@@ -10,7 +10,7 @@ LRESULT rp_Hfp(
 	double enth;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Hfp(
 
 	SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
         if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
             return MAKELRESULT(P_OUT_OF_RANGE, 2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_hft.h
+++ b/wrappers/Mathcad/includes/rp_hft.h
@@ -10,7 +10,7 @@ LRESULT rp_Hft(
 	double enth;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Hft(
 
 	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_hgp.h
+++ b/wrappers/Mathcad/includes/rp_hgp.h
@@ -10,7 +10,7 @@ LRESULT rp_Hgp(
 	double enth;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Hgp(
 
 	SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_hgt.h
+++ b/wrappers/Mathcad/includes/rp_hgt.h
@@ -10,7 +10,7 @@ LRESULT rp_Hgt(
 	double enth;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Hgt(
 
 	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_hps.h
+++ b/wrappers/Mathcad/includes/rp_hps.h
@@ -4,21 +4,21 @@ LRESULT rp_Hps(
     LPCCOMPLEXSCALAR      p,
     LPCCOMPLEXSCALAR      s   )
 {
-	char herr[255];
-	double pval,hval,sval,dval,tval;
+    char herr[255];
+    double pval,hval,sval,dval,tval;
     double tc, pc, Dc, sc;
-	double tsat,rhol,rhov,xliq[20],xvap[20],sliq,svap,hliq,hvap;
-	int ierr;
-	int kph = 1;
+    double tsat,rhol,rhov,xliq[20],xvap[20],sliq,svap,hliq,hvap;
+    int ierr;
+    int kph = 1;
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		pval = p->real * 1000.0;  // Convert from MPa to kPa
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        pval = p->real * 1000.0;  // Convert from MPa to kPa
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 2);
 
@@ -27,65 +27,65 @@ LRESULT rp_Hps(
         return MAKELRESULT(P_OUT_OF_RANGE, 2);
     
     if( s->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		sval = s->real * wmm;  // Convert from kJ/kg to J/mol
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        sval = s->real * wmm;  // Convert from kJ/kg to J/mol
 
-	// Are we above the critical pressure?
-	CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-	if (ierr != 0)
-		return MAKELRESULT(UNCONVERGED,1);
+    // Are we above the critical pressure?
+    CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+    if (ierr > 0)
+        return MAKELRESULT(UNCONVERGED,1);
 
-	if (pval < pc) // *** Below the Critical Point ***
+    if (pval < pc) // *** Below the Critical Point ***
     {
-		// Below the critical pressure
-		SATPdll(&pval, x, &kph, &tsat, &rhol, &rhov, xliq, xvap, &ierr, herr, errormessagelength);
-		if (ierr != 0)
-		{
-			if ((ierr == 2)||(ierr == 4)||(ierr == 141)) 
-				return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
-			else
-				return MAKELRESULT(UNCONVERGED,1); // failed to converge
-		}
-		ENTROdll(&tsat, &rhol, &x[0], &sliq);                           // Get Saturated Liquid Entropy at T
-		ENTROdll(&tsat, &rhov, &x[0], &svap);                           // Get Saturated Vapor Entropy at T
-		if ((sval >= sliq) && (sval <= svap))                           // IF within saturation curve
-		{                                    
-			ENTHALdll(&tsat, &rhol, &x[0], &hliq);                      //     Get Saturated Liquid Enthalpy at T
-			ENTHALdll(&tsat, &rhov, &x[0], &hvap);                      //     Get Saturated Vapor Enthalpy at T
-			hval = hliq + (hvap - hliq)*(sval - sliq) / (svap - sliq);  //     Interpolate hval
-			ret->real = hval / wmm;                                     //     convert to kJ/kg-
-			return 0;                                                   //     RETURN w/ no errors
-		}
-		else if (sval < sliq)                                           // IF below liquid entropy
-		{                                                               // initialize...
-			kph = 1;                                                    //    liquid phase
-			tval = tsat;                                                //    saturation temp
-			dval = rhol;                                                //    saturation density
-		}
-		else                                                            // ELSE above vapor entropy
-		{                                                               // initialize...
-			kph = 2;                                                    //    vapor phase
-			tval = tsat;                                                //    saturation temp
-			dval = rhov;                                                //    saturation density
-		}
-		PSFL1dll(&pval, &sval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
-		if (ierr != 0)
-			return MAKELRESULT(UNCONVERGED,1);
-		else
-		{
-			ENTHALdll(&tval,&dval, &x[0],&hval);                        // Get Enthalpy at T
-			ret->real = hval / wmm;                                     // convert to kJ/kg-K
-			return 0;
-		}
-	}                                    // *** above critical pressure ***
-	kph = 2;                                                            // use vapor iterations
-	tval = tc + 10.0;                                                   //   initialize t just above tc
-	dval = Dc * 2.0;                                                    //   initialize rho to 2 X Dc
-	ENTROdll(&tc, &Dc, &x[0], &sc);                                     //   check critical entropy
-	if (sval < sc/2.0) tval = tc * 0.8;                                 //   if very low entropy, reduce t guess
+        // Below the critical pressure
+        SATPdll(&pval, x, &kph, &tsat, &rhol, &rhov, xliq, xvap, &ierr, herr, errormessagelength);
+        if (ierr > 0)
+        {
+            if ((ierr == 2)||(ierr == 4)||(ierr == 141)) 
+                return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
+            else
+                return MAKELRESULT(UNCONVERGED,1); // failed to converge
+        }
+        ENTROdll(&tsat, &rhol, &x[0], &sliq);                           // Get Saturated Liquid Entropy at T
+        ENTROdll(&tsat, &rhov, &x[0], &svap);                           // Get Saturated Vapor Entropy at T
+        if ((sval >= sliq) && (sval <= svap))                           // IF within saturation curve
+        {                                    
+            ENTHALdll(&tsat, &rhol, &x[0], &hliq);                      //     Get Saturated Liquid Enthalpy at T
+            ENTHALdll(&tsat, &rhov, &x[0], &hvap);                      //     Get Saturated Vapor Enthalpy at T
+            hval = hliq + (hvap - hliq)*(sval - sliq) / (svap - sliq);  //     Interpolate hval
+            ret->real = hval / wmm;                                     //     convert to kJ/kg-
+            return 0;                                                   //     RETURN w/ no errors
+        }
+        else if (sval < sliq)                                           // IF below liquid entropy
+        {                                                               // initialize...
+            kph = 1;                                                    //    liquid phase
+            tval = tsat;                                                //    saturation temp
+            dval = rhol;                                                //    saturation density
+        }
+        else                                                            // ELSE above vapor entropy
+        {                                                               // initialize...
+            kph = 2;                                                    //    vapor phase
+            tval = tsat;                                                //    saturation temp
+            dval = rhov;                                                //    saturation density
+        }
+        PSFL1dll(&pval, &sval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
+        if (ierr > 0)
+            return MAKELRESULT(UNCONVERGED,1);
+        else
+        {
+            ENTHALdll(&tval,&dval, &x[0],&hval);                        // Get Enthalpy at T
+            ret->real = hval / wmm;                                     // convert to kJ/kg-K
+            return 0;
+        }
+    }                                    // *** above critical pressure ***
+    kph = 2;                                                            // use vapor iterations
+    tval = tc + 10.0;                                                   //   initialize t just above tc
+    dval = Dc * 2.0;                                                    //   initialize rho to 2 X Dc
+    ENTROdll(&tc, &Dc, &x[0], &sc);                                     //   check critical entropy
+    if (sval < sc/2.0) tval = tc * 0.8;                                 //   if very low entropy, reduce t guess
 
-	PSFL1dll(&pval, &sval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
+    PSFL1dll(&pval, &sval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
     if (ierr > 0) {
         if (ierr <= 12)
             return MAKELRESULT(P_OUT_OF_RANGE, 2);
@@ -94,10 +94,10 @@ LRESULT rp_Hps(
         else if (ierr == 250)
             return MAKELRESULT(S_OUT_OF_RANGE, 3);
         else
-    		return MAKELRESULT(UNCONVERGED,2);
+            return MAKELRESULT(UNCONVERGED,2);
     }
 
-	ENTHALdll(&tval, &dval, &x[0], &hval);                                // Get Enthalpy at T
+    ENTHALdll(&tval, &dval, &x[0], &hval);                                // Get Enthalpy at T
 
     ret->real = hval / wmm;                                               // convert to kJ/kg-K
 
@@ -110,13 +110,13 @@ FUNCTIONINFO    rp_hps =
     (char *)("rp_hps"),                 // Name by which mathcad will recognize the function
     (char *)("fluid,p,s"),              // rp_hps will be called as rp_hps(fluid,p,s)
     (char *)("Returns the enthalpy [kJ/kg] given the pressure [MPa] and entropy [kJ/kg-K]"),
-										// description of rp_hps(fluid,p,s)
+                                        // description of rp_hps(fluid,p,s)
     (LPCFUNCTION)rp_Hps,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 2 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
     
     

--- a/wrappers/Mathcad/includes/rp_htp.h
+++ b/wrappers/Mathcad/includes/rp_htp.h
@@ -4,28 +4,28 @@ LRESULT rp_Htp(
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      p   )
 {
-	double tval,pval,Dval;
+    double tval,pval,Dval;
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
     double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real;
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real;
 
     if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
@@ -35,8 +35,8 @@ LRESULT rp_Htp(
     // Get critical pressure
     if (ncomp > 1)
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr > 0)
         {
             return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -86,7 +86,7 @@ LRESULT rp_Htp(
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
     }
 
-	ret->real = H / wmm;   // Convert from J/mol to kJ/kg
+    ret->real = H / wmm;   // Convert from J/mol to kJ/kg
 
     return 0;               // return 0 to indicate there was no error
             
@@ -97,13 +97,13 @@ FUNCTIONINFO    rp_htp =
     (char *)("rp_htp"),                 // Name by which Mathcad will recognize the function
     (char *)("fluid,t,p"),              // rp_htp will be called as rp_htp(fluid,t,p)
     (char *)("Returns the enthalpy [kJ/kg] given the temperature [K] and pressure [MPa]"),
-										// description of rp_htp(fluid,t,p)
+                                        // description of rp_htp(fluid,t,p)
     (LPCFUNCTION)rp_Htp,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
     
     

--- a/wrappers/Mathcad/includes/rp_hts.h
+++ b/wrappers/Mathcad/includes/rp_hts.h
@@ -12,7 +12,7 @@ LRESULT rp_Hts(
 	int kr = 1;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )

--- a/wrappers/Mathcad/includes/rp_kfp.h
+++ b/wrappers/Mathcad/includes/rp_kfp.h
@@ -10,7 +10,7 @@ LRESULT rp_Kfp(
     double mu, cond;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (p->imag != 0.0)
@@ -20,7 +20,7 @@ LRESULT rp_Kfp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
             return MAKELRESULT(P_OUT_OF_RANGE, 2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_kft.h
+++ b/wrappers/Mathcad/includes/rp_kft.h
@@ -10,7 +10,7 @@ LRESULT rp_Kft(
     double mu, cond;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (t->imag != 0.0)
@@ -20,7 +20,7 @@ LRESULT rp_Kft(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 1) || (ierr == 9) || (ierr == 121))
             return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_kgp.h
+++ b/wrappers/Mathcad/includes/rp_kgp.h
@@ -10,7 +10,7 @@ LRESULT rp_Kgp(
     double mu, cond;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (p->imag != 0.0)
@@ -20,7 +20,7 @@ LRESULT rp_Kgp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
             return MAKELRESULT(P_OUT_OF_RANGE, 2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_kgt.h
+++ b/wrappers/Mathcad/includes/rp_kgt.h
@@ -10,7 +10,7 @@ LRESULT rp_Kgt(
     double mu, cond;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (t->imag != 0.0)
@@ -20,7 +20,7 @@ LRESULT rp_Kgt(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 1) || (ierr == 9) || (ierr == 121))
             return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_ktp.h
+++ b/wrappers/Mathcad/includes/rp_ktp.h
@@ -15,7 +15,7 @@ LRESULT rp_Ktp(
     char htype[] = "TCX";
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (t->imag != 0.0)
@@ -44,8 +44,8 @@ LRESULT rp_Ktp(
     // Get critical pressure
     if (ncomp > 1)
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr > 0)
         {
             return MAKELRESULT(UNCONVERGED, 2);
         }

--- a/wrappers/Mathcad/includes/rp_mufp.h
+++ b/wrappers/Mathcad/includes/rp_mufp.h
@@ -10,7 +10,7 @@ LRESULT rp_Mufp(
     double mu, cond;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (p->imag != 0.0)
@@ -20,7 +20,7 @@ LRESULT rp_Mufp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
             return MAKELRESULT(P_OUT_OF_RANGE, 2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_muft.h
+++ b/wrappers/Mathcad/includes/rp_muft.h
@@ -10,7 +10,7 @@ LRESULT rp_Muft(
     double mu, cond;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (t->imag != 0.0)
@@ -20,7 +20,7 @@ LRESULT rp_Muft(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 1) || (ierr == 9) || (ierr == 121))
             return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_mugp.h
+++ b/wrappers/Mathcad/includes/rp_mugp.h
@@ -10,7 +10,7 @@ LRESULT rp_Mugp(
     double mu, cond;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (p->imag != 0.0)
@@ -20,7 +20,7 @@ LRESULT rp_Mugp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
             return MAKELRESULT(P_OUT_OF_RANGE, 2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_mugt.h
+++ b/wrappers/Mathcad/includes/rp_mugt.h
@@ -10,7 +10,7 @@ LRESULT rp_Mugt(
     double mu, cond;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (t->imag != 0.0)
@@ -20,7 +20,7 @@ LRESULT rp_Mugt(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 1) || (ierr == 9) || (ierr == 121))
             return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_mutp.h
+++ b/wrappers/Mathcad/includes/rp_mutp.h
@@ -15,7 +15,7 @@ LRESULT rp_Mutp(
     char htype[] = "ETA";
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (t->imag != 0.0)
@@ -44,8 +44,8 @@ LRESULT rp_Mutp(
     // Get critical pressure
     if (ncomp > 1)
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr > 0)
         {
             return MAKELRESULT(UNCONVERGED, 2);
         }

--- a/wrappers/Mathcad/includes/rp_pcrit.h
+++ b/wrappers/Mathcad/includes/rp_pcrit.h
@@ -5,38 +5,39 @@ LRESULT rp_Pcrit(
     LPCMCSTRING        fluid,
     LPCCOMPLEXSCALAR    comp   )
 {
-	char herr[255];
+    char herr[255];
     unsigned int lherr = 255;
-	int ierr = 0;
-	int icomp = 1;
-	double wmm, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas; 
+    int ierr = 0;
+    int icomp = 1;
+    double wmm, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas; 
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( comp->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		icomp = static_cast<int>(comp->real);
-	
-	if ((icomp > ncomp)||(icomp < 0))
-		return MAKELRESULT(BAD_COMPONENT,2);
-    else if ((icomp == 0) && (ncomp > 1))
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        icomp = static_cast<int>(comp->real);
+
+    if ((icomp > ncomp)||(icomp < 0))
+        return MAKELRESULT(BAD_COMPONENT,2);
+
+    if ((icomp == 0) && (ncomp > 1))
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, lherr);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, lherr);
+        if (ierr > 0)
         {
-            return MAKELRESULT(UNCONVERGED, 2);
+            return MAKELRESULT(UNKNOWN, 2);
         }        
     }
-	else
-	{
-		if (icomp == 0) icomp = 1;
-		INFOdll(&icomp,&wmm,&ttrip,&tnbpt,&tc,&pc,&Dc,&Zc,&acf,&dip,&Rgas);
-	}
-		
-	ret->real = pc/1000.0;  // convert from kPa to MPa
+    else
+    {
+        if (icomp == 0) icomp = 1;
+        INFOdll(&icomp,&wmm,&ttrip,&tnbpt,&tc,&pc,&Dc,&Zc,&acf,&dip,&Rgas);
+    }
+        
+    ret->real = pc/1000.0;  // convert from kPa to MPa
 
     return 0;               // return 0 to indicate there was no error
             
@@ -47,11 +48,11 @@ FUNCTIONINFO    rp_pcrit =
     (char *)("rp_pcrit"),                          // Name by which mathcad will recognize the function
     (char *)("fluid,comp"),                        // rp_pcrit will be called as rp_pcrit(fluid,comp)
     (char *)("Returns critical pressure [MPa] of the component number specified"),
-										// description of rp_pcrit(fluid,comp)
+                                        // description of rp_pcrit(fluid,comp)
     (LPCFUNCTION)rp_Pcrit,              // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes on 1 argument
     { MC_STRING,
-	  COMPLEX_SCALAR }                  // argument is a complex scalar
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };
     

--- a/wrappers/Mathcad/includes/rp_phs.h
+++ b/wrappers/Mathcad/includes/rp_phs.h
@@ -12,7 +12,7 @@ LRESULT rp_Phs(
     int kph = 1;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (h->imag != 0.0)
@@ -28,7 +28,7 @@ LRESULT rp_Phs(
                                // Use the full HSFLSH function
 
     HSFLSHdll(&hval, &sval, &x[0], &tval, &pval, &dval, &rhol, &rhov, &xliq[0], &xvap[0], &qual, &eval, &Cv, &Cp, &wval, &ierr, herr, errormessagelength);
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 4) || (ierr == 12))
             return MAKELRESULT(P_OUT_OF_RANGE, 1);

--- a/wrappers/Mathcad/includes/rp_pmax.h
+++ b/wrappers/Mathcad/includes/rp_pmax.h
@@ -6,7 +6,7 @@ LRESULT rp_Pmax(
 	int ierr = 0;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 
 	ret->real = Pmax/1000.0;  // convert from kPa to MPa

--- a/wrappers/Mathcad/includes/rp_psatt.h
+++ b/wrappers/Mathcad/includes/rp_psatt.h
@@ -9,7 +9,7 @@ LRESULT rp_Psatt(
 	double psat,tsat,rhol,rhov,xliq[20],xvap[20];
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -19,7 +19,7 @@ LRESULT rp_Psatt(
 		
 	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_pth.h
+++ b/wrappers/Mathcad/includes/rp_pth.h
@@ -6,49 +6,49 @@ LRESULT rp_Pth(
     LPCCOMPLEXSCALAR      h,
     LPCCOMPLEXSCALAR      r   )
 {
-	char herr[errormessagelength];
-	double pval,hval,Dval,tval,qval;
-	double rhol,rhov,xliq[20],xvap[20];
+    char herr[errormessagelength];
+    double pval,hval,Dval,tval,qval;
+    double rhol,rhov,xliq[20],xvap[20];
     double U, S, Cv, Cp, W;
     double tc, pc, Dc;        //  , hvap, psat;    // no longer needed
-	int ierr;
-	int kph = 2;
-	int kr;
+    int ierr;
+    int kph = 2;
+    int kr;
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real;  // Temperature in K
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real;  // Temperature in K
 
     if( h->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		hval = h->real * wmm;  // Convert from kJ/kg to J/mol
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        hval = h->real * wmm;  // Convert from kJ/kg to J/mol
 
-	if( r->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,4);
-	else
-	{
-		kr = static_cast<int>(r->real);  // Convert to integer
-		// root must be 1 or 2...
-		if ((kr<1)||(kr>2)) return MAKELRESULT(INVALID_FLAG,4); 
-	}
+    if( r->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,4);
+    else
+    {
+        kr = static_cast<int>(r->real);  // Convert to integer
+        // root must be 1 or 2...
+        if ((kr<1)||(kr>2)) return MAKELRESULT(INVALID_FLAG,4); 
+    }
 
     // Upper root not supported in REFPROP 9.1 for T < Tc and H > Hvap.  Find Tc and check if kr == 2
     /* Fixed in REFPROP 10 *** Comment this section out ****
     if (kr == 2)
     {
         CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        if (ierr > 0)
             return MAKELRESULT(UNCONVERGED, 1);
         if (tval <= tc)
         {
             SATTdll(&tval, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
-            if (ierr != 0) {
+            if (ierr > 0) {
                 if ((ierr == 1) || (ierr == 9) || (ierr == 121))
                     return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit
                 else if (ierr == 8)
@@ -66,7 +66,7 @@ LRESULT rp_Pth(
     // REFPROP 10 Issue: Single-phase root confusion when T = Tc exactly
     // As a workaround, adjust tval slightly if Tc passed in
     CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(UNCONVERGED, 1);
     if (tval == tc) tval = tval + 0.0001;
 
@@ -85,8 +85,8 @@ LRESULT rp_Pth(
             return MAKELRESULT(UNCONVERGED, 1);
     }
 
-	// Otherwise...
-	ret->real = pval / 1000.0;       // Returned in MPa
+    // Otherwise...
+    ret->real = pval / 1000.0;       // Returned in MPa
 
     return 0;                        // return 0 to indicate there was no error
             
@@ -97,12 +97,12 @@ FUNCTIONINFO    rp_pth =
     (char *)("rp_pth"),                 // Name by which mathcad will recognize the function
     (char *)("fluid,t,h,r"),            // rp_pth will be called as rp_pth(fluid,t,h,r)
     (char *)("Returns the pressure [MPa] given the temperature [K] and enthalpy [kJ/kg]"),
-										// description of rp_pth(fluid,t,h,r)
+                                        // description of rp_pth(fluid,t,h,r)
     (LPCFUNCTION)rp_Pth,				// pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     4,                                  // the function takes on 4 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };

--- a/wrappers/Mathcad/includes/rp_ptrho.h
+++ b/wrappers/Mathcad/includes/rp_ptrho.h
@@ -8,7 +8,7 @@ LRESULT rp_Ptrho(
 	int ierr;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (t->imag != 0.0)

--- a/wrappers/Mathcad/includes/rp_ptrip.h
+++ b/wrappers/Mathcad/includes/rp_ptrip.h
@@ -3,32 +3,32 @@ LRESULT rp_Ptrip(
     LPCMCSTRING       fluid,
     LPCCOMPLEXSCALAR   comp   )
 {
-	char herr[256] = "OK\0";
-	char htyp[4] = "EOS";
-	unsigned int lhtyp = 3;
+    char herr[256] = "OK\0";
+    char htyp[4] = "EOS";
+    unsigned int lhtyp = 3;
     unsigned int lherr = 255;
-	int ierr = 0;
-	int icomp = 1;
-	int kph = 1;
-	double D,Dl,Dv,xl[20],xv[20],Umol,Hmol,Smol,Cv,Cp,w;
+    int ierr = 0;
+    int icomp = 1;
+    int kph = 1;
+    double D,Dl,Dv,xl[20],xv[20],Umol,Hmol,Smol,Cv,Cp,w;
     double wmm, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
-	double ttrip = 0.0;
-	double ptrip = 0.0;
-	double dtrip = 0.0;
+    double ttrip = 0.0;
+    double ptrip = 0.0;
+    double dtrip = 0.0;
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( comp->imag != 0.0 )            // If Imaginary part of component not zero..
-		return MAKELRESULT(MUST_BE_REAL,2);       //    Return and error,
-	else
-		icomp = static_cast<int>(comp->real);       //    Otherwise, get the real part.
-	
-	if ((icomp > ncomp)||(icomp < 0))  // Illegal component number...
-		return MAKELRESULT(BAD_COMPONENT,2);      //    ...Return and error.
-	else
-	{
+        return MAKELRESULT(MUST_BE_REAL,2);       //    Return and error,
+    else
+        icomp = static_cast<int>(comp->real);       //    Otherwise, get the real part.
+    
+    if ((icomp > ncomp)||(icomp < 0))  // Illegal component number...
+        return MAKELRESULT(BAD_COMPONENT,2);      //    ...Return and error.
+    else
+    {
         if ((icomp == 0) && (ncomp > 1))
             LIMITSdll(htyp, &x[0], &ttrip, &Tmax, &Dmax, &Pmax, lhtyp);
         else
@@ -40,16 +40,16 @@ LRESULT rp_Ptrip(
 
         TQFLSHdll(&ttrip, &_Q, &x[0], &kph, &ptrip, &D, &Dl, &Dv, &xl[0], &xv[0], &Umol, &Hmol, &Smol, &Cv, &Cp, &w, &ierr, herr, errormessagelength);
 
-		if (ierr != 0)
-		{
-			if ((ierr == 1)||(ierr == 8)||(ierr == 9))
-				return MAKELRESULT(T_OUT_OF_RANGE,2);
+        if (ierr > 0)
+        {
+            if ((ierr == 1)||(ierr == 8)||(ierr == 9))
+                return MAKELRESULT(T_OUT_OF_RANGE,2);
             else
-				return MAKELRESULT(UNCONVERGED,2);
-		}
-	}
-		
-	ret->real = ptrip/1000.0;  // convert from kPa to MPa
+                return MAKELRESULT(UNCONVERGED,2);
+        }
+    }
+        
+    ret->real = ptrip/1000.0;  // convert from kPa to MPa
 
     return 0;                  // return 0 to indicate there was no error
             
@@ -60,11 +60,11 @@ FUNCTIONINFO    rp_ptrip =
     (char *)("rp_ptrip"),               // Name by which mathcad will recognize the function
     (char *)("fluid,comp"),             // rp_ptrip will be called as rp_ptrip(fluid,comp)
     (char *)("Returns triple point pressure [MPa] of the component number specified"),
-										// description of rp_ptrip(fluid,comp)
+                                        // description of rp_ptrip(fluid,comp)
     (LPCFUNCTION)rp_Ptrip,              // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes on 1 argument
     { MC_STRING,
-	  COMPLEX_SCALAR }                  // argument is a complex scalar
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };
     

--- a/wrappers/Mathcad/includes/rp_pts.h
+++ b/wrappers/Mathcad/includes/rp_pts.h
@@ -4,56 +4,56 @@ LRESULT rp_Pts(
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      s   )
 {
-	char herr[errormessagelength];
-	double pval,sval,Dval,tval,qval;
-	double rhol, rhov, xliq[20], xvap[20];
+    char herr[errormessagelength];
+    double pval,sval,Dval,tval,qval;
+    double rhol, rhov, xliq[20], xvap[20];
     double U, H, Cv, Cp, W;
     int ierr;
-	int kph = 2;
-	int kr = 1;   // No dual roots for entropy functions
+    int kph = 2;
+    int kr = 1;   // No dual roots for entropy functions
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real;  // Temperature in K
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real;  // Temperature in K
 
     if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
 
     if( s->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		sval = s->real * wmm;  // Convert from kJ/kg-K to J/mol-K
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        sval = s->real * wmm;  // Convert from kJ/kg-K to J/mol-K
 
-	pval = 0.0;
+    pval = 0.0;
 
     TSFLSHdll(&tval, &sval, &x[0], &kr, &pval, &Dval, &rhol, &rhov, &xliq[0], &xvap[0], &qval, &U, &H, &Cv, &Cp, &W, &ierr, herr, errormessagelength);
 
-	if (ierr > 0)
-	{
-		if (ierr == 250)
-		{
-			return MAKELRESULT(S_OUT_OF_RANGE,3);
-		}
-		else if (ierr <= 12)
-		{
-			return MAKELRESULT(P_OUT_OF_RANGE,2);
-		}
-		else
-		{
-			return MAKELRESULT(UNCONVERGED,1);
-		}
-	}
+    if (ierr > 0)
+    {
+        if (ierr == 250)
+        {
+            return MAKELRESULT(S_OUT_OF_RANGE,3);
+        }
+        else if (ierr <= 12)
+        {
+            return MAKELRESULT(P_OUT_OF_RANGE,2);
+        }
+        else
+        {
+            return MAKELRESULT(UNCONVERGED,1);
+        }
+    }
 
-	// If pval > Pmax, return error 4
-	if (pval > Pmax + extr * Pmax)
-		return MAKELRESULT(P_OUT_OF_RANGE,1);
+    // If pval > Pmax, return error 4
+    if (pval > Pmax + extr * Pmax)
+        return MAKELRESULT(P_OUT_OF_RANGE,1);
 
-	// Otherwise...
-	ret->real = pval / 1000.0;       // Returned in MPa
+    // Otherwise...
+    ret->real = pval / 1000.0;       // Returned in MPa
 
     return 0;               // return 0 to indicate there was no error
             
@@ -64,13 +64,13 @@ FUNCTIONINFO    rp_pts =
     (char *)("rp_pts"),                 // Name by which mathcad will recognize the function
     (char *)("fluid,t,s,r"),            // rp_pts will be called as rp_pts(fluid,t,s,r)
     (char *)("Returns the pressure [MPa] given the temperature [K] and entropy [kJ/kg-K]"),
-										// description of rp_pts(fluid,t,s,r)
+                                        // description of rp_pts(fluid,t,s,r)
     (LPCFUNCTION)rp_Pts,				// pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
 
     

--- a/wrappers/Mathcad/includes/rp_rgas.h
+++ b/wrappers/Mathcad/includes/rp_rgas.h
@@ -3,19 +3,19 @@ LRESULT rp_Rgas(
     LPCMCSTRING       fluid,
     LPCCOMPLEXSCALAR   comp   )
 {
-	int ierr = 0;
-	int icomp = 1;
-	double wmm, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas; 
+    int ierr = 0;
+    int icomp = 1;
+    double wmm, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas; 
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( comp->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		icomp = static_cast<int>(comp->real);
-	
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        icomp = static_cast<int>(comp->real);
+    
     if ((icomp > ncomp) || (icomp < 0))
     {
         return MAKELRESULT(BAD_COMPONENT, 2);
@@ -40,11 +40,11 @@ FUNCTIONINFO    rp_rgas =
     (char *)("rp_rgas"),                // Name by which Mathcad will recognize the function
     (char *)("comp"),                   // rp_rgas will be called as rp_rgas(comp)
     (char *)("Returns the gas constant [J/mol-K] of the component number or mixture specified"),
-										// description of rp_rgas(comp)
+                                        // description of rp_rgas(comp)
     (LPCFUNCTION)rp_Rgas,               // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes on 1 argument
     { MC_STRING,
-	  COMPLEX_SCALAR }                  // argument is a complex scalar
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };
     

--- a/wrappers/Mathcad/includes/rp_rhocrit.h
+++ b/wrappers/Mathcad/includes/rp_rhocrit.h
@@ -3,39 +3,39 @@ LRESULT rp_Rhocrit(
     LPCMCSTRING       fluid,
     LPCCOMPLEXSCALAR   comp   )
 {
-	char herr[256] = "Ok\0";
+    char herr[256] = "Ok\0";
     unsigned int lherr = 255;
-	int ierr = 0;
-	int icomp = 1;
-	double wmm0, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas; 
+    int ierr = 0;
+    int icomp = 1;
+    double wmm0, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas; 
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( comp->imag != 0.0 )
-		return MAKELRESULT(1,2);
-	else
-		icomp = static_cast<int>(comp->real);
-	
-	if ((icomp > ncomp)||(icomp < 0))
-		return MAKELRESULT(10,2);
-	else if ((icomp == 0)&&(ncomp > 1))
-	{
-		CRITPdll(x,&tc,&pc,&Dc,&ierr,herr,lherr);
-		if (ierr != 0)
-		{
-			return MAKELRESULT(9,2);
-		}
-		wmm0 = wmm;
-	}
-	else 
-	{
-		if (icomp == 0) icomp = 1;
-		INFOdll(&icomp,&wmm0,&ttrip,&tnbpt,&tc,&pc,&Dc,&Zc,&acf,&dip,&Rgas);
-	}
-		
-	ret->real = Dc*wmm0;   // convert from mol/L to kg/m^3
+        return MAKELRESULT(1,2);
+    else
+        icomp = static_cast<int>(comp->real);
+    
+    if ((icomp > ncomp)||(icomp < 0))
+        return MAKELRESULT(10,2);
+    else if ((icomp == 0)&&(ncomp > 1))
+    {
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, lherr);
+        if (ierr > 0)
+        {
+            return MAKELRESULT(9,2);
+        }
+        wmm0 = wmm;
+    }
+    else 
+    {
+        if (icomp == 0) icomp = 1;
+        INFOdll(&icomp,&wmm0,&ttrip,&tnbpt,&tc,&pc,&Dc,&Zc,&acf,&dip,&Rgas);
+    }
+        
+    ret->real = Dc*wmm0;   // convert from mol/L to kg/m^3
 
     return 0;             // return 0 to indicate there was no error
             
@@ -46,11 +46,11 @@ FUNCTIONINFO    rp_rhocrit =
     (char *)("rp_rhocrit"),             // Name by which Mathcad will recognize the function
     (char *)("fluid,comp"),             // rp_rhocrit will be called as rp_rhocrit(fluid,comp)
     (char *)("Returns the critical point density [kg/m^3] of the component number specified"),
-										// description of rp_rhocrit(fluid,comp)
+                                        // description of rp_rhocrit(fluid,comp)
     (LPCFUNCTION)rp_Rhocrit,            // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes on 1 argument
     { MC_STRING,
-	  COMPLEX_SCALAR }                  // argument is a complex scalar
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };
     

--- a/wrappers/Mathcad/includes/rp_rhofp.h
+++ b/wrappers/Mathcad/includes/rp_rhofp.h
@@ -3,31 +3,31 @@ LRESULT rp_Rhofp(
     LPCMCSTRING       fluid,
     LPCCOMPLEXSCALAR      p   )
 {
-	char herr[256] = "OK\0";
+    char herr[256] = "OK\0";
     unsigned int lenherr = 3;
-	int kph = 1;   // looking for saturated liquid (bubble point)
-	int ierr;
-	double psat,tsat,rhol,rhov,xliq[20],xvap[20];
+    int kph = 1;   // looking for saturated liquid (bubble point)
+    int ierr;
+    double psat,tsat,rhol,rhov,xliq[20],xvap[20];
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
-	
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,1);
-	else
-		psat = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP input
+        return MAKELRESULT(MUST_BE_REAL,1);
+    else
+        psat = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP input
 
-	SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,lenherr);
+    SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,lenherr);
 
-	if (ierr != 0)
-	{
-		if ((ierr == 2)||(ierr == 4) || (ierr == 12) ||(ierr == 141))
-			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
-		else
-			return MAKELRESULT(UNCONVERGED,1); // failed to converge
-	}
-	ret->real = rhol*wmm;   // Convert from mol/L to kg/m³
+    if (ierr > 0)
+    {
+        if ((ierr == 2)||(ierr == 4) || (ierr == 12) ||(ierr == 141))
+            return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
+        else
+            return MAKELRESULT(UNCONVERGED,1); // failed to converge
+    }
+    ret->real = rhol*wmm;   // Convert from mol/L to kg/m³
 
     return 0;               // return 0 to indicate there was no error
             
@@ -38,12 +38,12 @@ FUNCTIONINFO    rp_rhofp =
     (char *)("rp_rhofp"),               // Name by which Mathcad will recognize the function
     (char *)("fluid,p"),                // rp_rhofp will be called as rp_rhofp(fluid,p)
     (char *)("Returns the saturation liquid density [kg/m³] given the pressure [MPa]"),
-										// description of rp_rhofp(fluid,p)
+                                        // description of rp_rhofp(fluid,p)
     (LPCFUNCTION)rp_Rhofp,              // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes on 2 arguments
     { MC_STRING,
-	  COMPLEX_SCALAR }                  // argument is a complex scalar
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };
     
     

--- a/wrappers/Mathcad/includes/rp_rhoft.h
+++ b/wrappers/Mathcad/includes/rp_rhoft.h
@@ -3,33 +3,33 @@ LRESULT rp_Rhoft(
     LPCMCSTRING       fluid,
     LPCCOMPLEXSCALAR      t   )
 {
-	char herr[256] = "OK\0";
+    char herr[256] = "OK\0";
     unsigned int lenherr = 3;
-	int kph = 1;   // looking for saturated liquid (bubble point)
-	int ierr;
-	double psat,tsat,rhol,rhov,xliq[20],xvap[20];
+    int kph = 1;   // looking for saturated liquid (bubble point)
+    int ierr;
+    double psat,tsat,rhol,rhov,xliq[20],xvap[20];
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
-	
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,1);
-	else
-		tsat = t->real;            // T in [K]
+        return MAKELRESULT(MUST_BE_REAL,1);
+    else
+        tsat = t->real;            // T in [K]
 
-	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,lenherr);
+    SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,lenherr);
 
-	if (ierr != 0)
-	{
-		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
-			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit
-		else if (ierr == 8)
-			return MAKELRESULT(BAD_COMPONENT,2); // x out of range
+    if (ierr > 0)
+    {
+        if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
+            return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit
+        else if (ierr == 8)
+            return MAKELRESULT(BAD_COMPONENT,2); // x out of range
         else 
             return MAKELRESULT(UNCONVERGED, 2); // failed to converge
     }
-	ret->real = rhol*wmm;   // Convert from mol/L to kg/m³
+    ret->real = rhol*wmm;   // Convert from mol/L to kg/m³
 
     return 0;               // return 0 to indicate there was no error
             
@@ -40,12 +40,12 @@ FUNCTIONINFO    rp_rhoft =
     (char*)("rp_rhoft"),                // Name by which mathcad will recognize the function
     (char*)("fluid,t"),                 // rp_rhoft will be called as rp_rhoft(fluid,t)
     (char*)("Returns the saturation liquid density [kg/m³] given the temperature [K]"),
-										// description of rp_rhoft(fluid,p)
+                                        // description of rp_rhoft(fluid,p)
     (LPCFUNCTION)rp_Rhoft,              // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes on 2 arguments
     { MC_STRING,
-	  COMPLEX_SCALAR }                  // argument is a complex scalar
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };
     
     

--- a/wrappers/Mathcad/includes/rp_rhogp.h
+++ b/wrappers/Mathcad/includes/rp_rhogp.h
@@ -10,7 +10,7 @@ LRESULT rp_Rhogp(
     double psat, tsat, rhol, rhov, xliq[20] = { 0.0 }, xvap[20] = { 0.0 };
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Rhogp(
 
 	SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,lenherr);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2)||(ierr == 4) || (ierr == 12) ||(ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_rhogt.h
+++ b/wrappers/Mathcad/includes/rp_rhogt.h
@@ -9,7 +9,7 @@ LRESULT rp_Rhogt(
 	double psat,tsat,rhol,rhov,xliq[20],xvap[20];
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -19,7 +19,7 @@ LRESULT rp_Rhogt(
 
 	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_rhomax.h
+++ b/wrappers/Mathcad/includes/rp_rhomax.h
@@ -2,23 +2,23 @@ LRESULT rp_Rhomax(
     LPCOMPLEXSCALAR     ret,
     LPCMCSTRING       fluid   )
 {
-	char herr[255];
+    char herr[255];
     unsigned int lherr = 255;
-	int ierr = 0;
-	int icomp = 0;
-	double tc, pc, Dc; 
+    int ierr = 0;
+    int icomp = 0;
+    double tc, pc, Dc; 
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
-	CRITPdll(&x[0],&tc,&pc,&Dc,&ierr,herr,lherr);
-	if (ierr != 0)
-	{
-		return MAKELRESULT(UNCONVERGED,2);
-	}
-		
-	ret->real = Dmax*wmm;   // convert from mol/L to kg/m^3
+    CRITPdll(&x[0],&tc,&pc,&Dc,&ierr,herr,lherr);
+    if (ierr > 0)
+    {
+        return MAKELRESULT(UNCONVERGED,2);
+    }
+        
+    ret->real = Dmax*wmm;   // convert from mol/L to kg/m^3
 
     return 0;             // return 0 to indicate there was no error
             
@@ -29,7 +29,7 @@ FUNCTIONINFO    rp_rhomax =
     (char *)("rp_rhomax"),         // Name by which Mathcad will recognize the function
     (char *)("fluid"),             // rp_rhomax will be called as rp_rhomax(fluid)
     (char *)("Returns the maximum density [kg/m^3] of the fluid/mixture specified"),
-								   // description of rp_rhomax(fluid)
+                                   // description of rp_rhomax(fluid)
     (LPCFUNCTION)rp_Rhomax,        // pointer to the executable code
     COMPLEX_SCALAR,                // the return type is a complex scalar
     1,                             // the function takes on 1 argument

--- a/wrappers/Mathcad/includes/rp_rhoph.h
+++ b/wrappers/Mathcad/includes/rp_rhoph.h
@@ -12,7 +12,7 @@ LRESULT rp_Rhoph(
     int kph = 1;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (p->imag != 0.0)
@@ -29,14 +29,14 @@ LRESULT rp_Rhoph(
 
                                // Are we above the critical pressure?
     CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(UNCONVERGED, 1);
 
     if (pval < pc)
     {
         // Below the critical pressure
         SATPdll(&pval, &x[0], &kph, &tsat, &rhol, &rhov, xliq, xvap, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        if (ierr > 0)
         {
             if ((ierr == 2) || (ierr == 4) || (ierr == 141))
                 return MAKELRESULT(P_OUT_OF_RANGE, 2); // Pressure too low | negative | > Pcrit
@@ -66,7 +66,7 @@ LRESULT rp_Rhoph(
             dval = rhov;                     //    saturation density
         }
         PHFL1dll(&pval, &hval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        if (ierr > 0)
             return MAKELRESULT(UNCONVERGED, 1);
         else
         {

--- a/wrappers/Mathcad/includes/rp_rhops.h
+++ b/wrappers/Mathcad/includes/rp_rhops.h
@@ -12,7 +12,7 @@ LRESULT rp_Rhops(
     int kph = 1;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (p->imag != 0.0)
@@ -29,14 +29,14 @@ LRESULT rp_Rhops(
 
                                // Are we above the critical pressure?
     CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(UNCONVERGED, 1);
 
     if (pval < pc) // *** Below the Critical Point ***
     {
         // Below the critical pressure
         SATPdll(&pval, x, &kph, &tsat, &rhol, &rhov, xliq, xvap, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        if (ierr > 0)
         {
             if ((ierr == 2) || (ierr == 4) || (ierr == 141))
                 return MAKELRESULT(P_OUT_OF_RANGE, 2); // Pressure too low | negative | > Pcrit
@@ -66,7 +66,7 @@ LRESULT rp_Rhops(
             dval = rhov;                                                //    saturation density
         }
         PSFL1dll(&pval, &sval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        if (ierr > 0)
             return MAKELRESULT(UNCONVERGED, 1);
         else
         {

--- a/wrappers/Mathcad/includes/rp_rhoth.h
+++ b/wrappers/Mathcad/includes/rp_rhoth.h
@@ -15,7 +15,7 @@ LRESULT rp_Rhoth(
     int kr;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0 )
+    if (ierr > 0)
         return MAKELRESULT(ierr,1);
 
     if (t->imag != 0.0)
@@ -44,12 +44,12 @@ LRESULT rp_Rhoth(
     if (kr == 2)
     {
         CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        if (ierr > 0)
             return MAKELRESULT(UNCONVERGED, 1);
         if (tval <= tc)
         {
             SATTdll(&tval, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
-            if (ierr != 0) {
+            if (ierr > 0) {
                 if ((ierr == 1) || (ierr == 9) || (ierr == 121))
                     return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit
                 else if (ierr == 8)
@@ -67,7 +67,7 @@ LRESULT rp_Rhoth(
     // REFPROP 10 Issue: Single-phase root confusion when T = Tc exactly
     // As a workaround, adjust tval slightly if Tc passed in
     CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(UNCONVERGED, 1);
     if (tval == tc) tval = tval + 0.0001;
 

--- a/wrappers/Mathcad/includes/rp_rhotp.h
+++ b/wrappers/Mathcad/includes/rp_rhotp.h
@@ -4,28 +4,28 @@ LRESULT rp_Rhotp(
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      p   )
 {
-	double tval,pval,Dval;
+    double tval,pval,Dval;
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
     double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real;
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real;
 
     if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
@@ -35,8 +35,8 @@ LRESULT rp_Rhotp(
     // Get critical pressure
     if (ncomp > 1)
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr > 0)
         {
             return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -88,7 +88,7 @@ LRESULT rp_Rhotp(
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
     }
-	ret->real = Dval*wmm;   // Convert from mol/L to kg/m³
+    ret->real = Dval*wmm;   // Convert from mol/L to kg/m³
 
     return 0;               // return 0 to indicate there was no error
             
@@ -99,13 +99,11 @@ FUNCTIONINFO    rp_rhotp =
     (char *)("rp_rhotp"),               // Name by which Mathcad will recognize the function
     (char *)("fluid,t,p"),              // rp_rhotp will be called as rp_rhotp(fluid,t,p)
     (char *)("Returns the density [kg/m³] given the temperature [K] and pressure [MPa]"),
-										// description of rp_rhotp(fluid,t,p)
+                                        // description of rp_rhotp(fluid,t,p)
     (LPCFUNCTION)rp_Rhotp,              // pointer to the executible code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
-    
-    

--- a/wrappers/Mathcad/includes/rp_rhots.h
+++ b/wrappers/Mathcad/includes/rp_rhots.h
@@ -13,7 +13,7 @@ LRESULT rp_Rhots(
     int kr = 1;     // No dual roots for entropy functions (only enthalpy)
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0 )
+    if (ierr > 0)
         return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )

--- a/wrappers/Mathcad/includes/rp_sfp.h
+++ b/wrappers/Mathcad/includes/rp_sfp.h
@@ -10,7 +10,7 @@ LRESULT rp_Sfp(
 	double S;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Sfp(
 
 	SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_sft.h
+++ b/wrappers/Mathcad/includes/rp_sft.h
@@ -10,7 +10,7 @@ LRESULT rp_Sft(
 	double S;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Sft(
 
 	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_sgp.h
+++ b/wrappers/Mathcad/includes/rp_sgp.h
@@ -10,7 +10,7 @@ LRESULT rp_Sgp(
 	double S;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Sgp(
 
 	SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_sgt.h
+++ b/wrappers/Mathcad/includes/rp_sgt.h
@@ -10,7 +10,7 @@ LRESULT rp_Sgt(
 	double S;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Sgt(
 
 	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_sph.h
+++ b/wrappers/Mathcad/includes/rp_sph.h
@@ -4,21 +4,21 @@ LRESULT rp_Sph(
     LPCCOMPLEXSCALAR      p,
     LPCCOMPLEXSCALAR      h   )
 {
-	char herr[errormessagelength];
-	double pval, hval, sval, dval, tval;
-	double pc, tc, Dc, hc;
-	double tsat, rhol, rhov, xliq[20], xvap[20], hliq, hvap, sliq, svap;
-	int ierr;
-	int kph = 1;
+    char herr[errormessagelength];
+    double pval, hval, sval, dval, tval;
+    double pc, tc, Dc, hc;
+    double tsat, rhol, rhov, xliq[20], xvap[20], hliq, hvap, sliq, svap;
+    int ierr;
+    int kph = 1;
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		pval = p->real * 1000.0;  // Convert from MPa to kPa
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        pval = p->real * 1000.0;  // Convert from MPa to kPa
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 2);
 
@@ -27,70 +27,70 @@ LRESULT rp_Sph(
         return MAKELRESULT(P_OUT_OF_RANGE, 2);
 
     if( h->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		hval = h->real * wmm;  // Convert from kJ/kg to J/mol
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        hval = h->real * wmm;  // Convert from kJ/kg to J/mol
 
-	// Are we above the critical pressure?
-	CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-	if (ierr != 0)
-		return MAKELRESULT(UNCONVERGED,1);
+    // Are we above the critical pressure?
+    CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+    if (ierr > 0)
+        return MAKELRESULT(UNCONVERGED,1);
 
-	if (pval < pc)
-	{
-		// Below the critical pressure
-		SATPdll(&pval, &x[0], &kph, &tsat, &rhol, &rhov, xliq, xvap, &ierr, herr, errormessagelength);
-		if (ierr != 0)
-		{
-			if ((ierr == 2)||(ierr == 4)||(ierr == 141)) 
-				return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
-			else
-				return MAKELRESULT(UNCONVERGED,1); // failed to converge
-		}
-		ENTHALdll(&tsat, &rhol, &x[0], &hliq);         // Get Saturated Liquid Enthalpy at T
-		ENTHALdll(&tsat, &rhov, &x[0], &hvap);         // Get Saturated Vapor Enthalpy at T
-		if ((hval >= hliq) && (hval <= hvap))
-		{                                    // within saturation curve
-			ENTROdll(&tsat, &rhol, &x[0], &sliq);      // Get Saturated Liquid Entropy at T
-			ENTROdll(&tsat, &rhov, &x[0], &svap);      // Get Saturated Vapor Entropy at T
-			sval = sliq + (svap - sliq)*(hval - hliq) / (hvap - hliq);  // Interpolate sval
-			ret->real = sval / wmm;            // convert to kJ/kg-K
-			return 0;
-		}
-		if (hval < hliq)                     // below liquid enthalpy
-		{                                    // initialize...
-			kph = 1;                         //    liquid phase
-			tval = tsat;                     //    saturation temp
-			dval = rhol;                     //    saturation density
-		}
-		else                                 // above vapor enthalpy
-		{                                    // initialize...
-			kph = 2;                         //    vapor phase
-			tval = tsat;                     //    saturation temp
-			dval = rhov;                     //    saturation density
-		}
-		PHFL1dll(&pval, &hval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
-		if (ierr != 0)
-			return MAKELRESULT(UNCONVERGED,1);
-		else
-		{
-			ENTROdll(&tval, &dval, &x[0], &sval);
-			ret->real = sval / wmm;          // convert to kJ/kg-K
-			return 0;
-		}
-	}                                    // above critical pressure
-	kph = 2;                             // use vapor iterations
-	tval = tc + 10.0;                    //   initialize t just above tc
-	dval = Dc * 2.0;                     //   initialize rho to 2 X Dc
-	ENTHALdll(&tc, &Dc, &x[0], &hc);     //   check critical enthalpy
-	if (hval < hc/2.0) tval = tc * 0.8;  //   if very low enthalpy, reduce t guess
+    if (pval < pc)
+    {
+        // Below the critical pressure
+        SATPdll(&pval, &x[0], &kph, &tsat, &rhol, &rhov, xliq, xvap, &ierr, herr, errormessagelength);
+        if (ierr > 0)
+        {
+            if ((ierr == 2)||(ierr == 4)||(ierr == 141)) 
+                return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
+            else
+                return MAKELRESULT(UNCONVERGED,1); // failed to converge
+        }
+        ENTHALdll(&tsat, &rhol, &x[0], &hliq);         // Get Saturated Liquid Enthalpy at T
+        ENTHALdll(&tsat, &rhov, &x[0], &hvap);         // Get Saturated Vapor Enthalpy at T
+        if ((hval >= hliq) && (hval <= hvap))
+        {                                    // within saturation curve
+            ENTROdll(&tsat, &rhol, &x[0], &sliq);      // Get Saturated Liquid Entropy at T
+            ENTROdll(&tsat, &rhov, &x[0], &svap);      // Get Saturated Vapor Entropy at T
+            sval = sliq + (svap - sliq)*(hval - hliq) / (hvap - hliq);  // Interpolate sval
+            ret->real = sval / wmm;            // convert to kJ/kg-K
+            return 0;
+        }
+        if (hval < hliq)                     // below liquid enthalpy
+        {                                    // initialize...
+            kph = 1;                         //    liquid phase
+            tval = tsat;                     //    saturation temp
+            dval = rhol;                     //    saturation density
+        }
+        else                                 // above vapor enthalpy
+        {                                    // initialize...
+            kph = 2;                         //    vapor phase
+            tval = tsat;                     //    saturation temp
+            dval = rhov;                     //    saturation density
+        }
+        PHFL1dll(&pval, &hval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
+        if (ierr > 0)
+            return MAKELRESULT(UNCONVERGED,1);
+        else
+        {
+            ENTROdll(&tval, &dval, &x[0], &sval);
+            ret->real = sval / wmm;          // convert to kJ/kg-K
+            return 0;
+        }
+    }                                    // above critical pressure
+    kph = 2;                             // use vapor iterations
+    tval = tc + 10.0;                    //   initialize t just above tc
+    dval = Dc * 2.0;                     //   initialize rho to 2 X Dc
+    ENTHALdll(&tc, &Dc, &x[0], &hc);     //   check critical enthalpy
+    if (hval < hc/2.0) tval = tc * 0.8;  //   if very low enthalpy, reduce t guess
 
-	PHFL1dll(&pval, &hval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
-	if (ierr != 0)
-		return MAKELRESULT(UNCONVERGED,1);
+    PHFL1dll(&pval, &hval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
+    if (ierr > 0)
+        return MAKELRESULT(UNCONVERGED,1);
 
-	ENTROdll(&tval, &dval, &x[0], &sval);
-	ret->real = sval / wmm;            // convert to kJ/kg-K
+    ENTROdll(&tval, &dval, &x[0], &sval);
+    ret->real = sval / wmm;            // convert to kJ/kg-K
 
     return 0;               // return 0 to indicate there was no error
             
@@ -101,11 +101,11 @@ FUNCTIONINFO    rp_sph =
     (char *)("rp_sph"),                 // Name by which mathcad will recognize the function
     (char *)("fluid,p,h"),              // rp_sph will be called as rp_sph(fluid,p,h)
     (char *)("Returns the Entropy [kJ/kg-K] given the pressure [MPa] and enthalpy [kJ/kg]"),
-										// description of rp_sph(fluid,p,h)
+                                        // description of rp_sph(fluid,p,h)
     (LPCFUNCTION)rp_Sph,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };

--- a/wrappers/Mathcad/includes/rp_sth.h
+++ b/wrappers/Mathcad/includes/rp_sth.h
@@ -5,22 +5,22 @@ LRESULT rp_Sth(
     LPCCOMPLEXSCALAR      h,
     LPCCOMPLEXSCALAR      r   )
 {
-	char herr[errormessagelength];
-	double pval,hval,sval,dval,tval;
-	double rhol,rhov,xliq[20],xvap[20],qval,uval,cv,cp,wval;
+    char herr[errormessagelength];
+    double pval,hval,sval,dval,tval;
+    double rhol,rhov,xliq[20],xvap[20],qval,uval,cv,cp,wval;
     double tc, pc, Dc;        //  , hvap, psat;    // no longer needed
     int ierr;
-	int kph = 1;
-	int kr = 1;
+    int kph = 1;
+    int kr = 1;
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real ;  // Get Temperature in K
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real ;  // Get Temperature in K
 
     if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
 
@@ -29,30 +29,30 @@ LRESULT rp_Sth(
         return MAKELRESULT(T_OUT_OF_RANGE, 3);
 
     if( h->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		hval = h->real * wmm;  // Convert from kJ/kg to J/mol
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        hval = h->real * wmm;  // Convert from kJ/kg to J/mol
 
-	if( r->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,4);
-	else
-	{
-		kr = static_cast<int>(r->real);  // Convert to integer
-		// root must be 1 or 2...
-		if ((kr<1)||(kr>2)) return MAKELRESULT(INVALID_FLAG,4); 
-	}
+    if( r->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,4);
+    else
+    {
+        kr = static_cast<int>(r->real);  // Convert to integer
+        // root must be 1 or 2...
+        if ((kr<1)||(kr>2)) return MAKELRESULT(INVALID_FLAG,4); 
+    }
 
     // Upper root not supported in REFPROP 9.1 for T < Tc and H > Hvap.  Find Tc and check if kr == 2
     /* Fixed in REFPROP 10 *** Comment this section out ****
     if (kr == 2)
     {
         CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        if (ierr > 0)
             return MAKELRESULT(UNCONVERGED, 1);
         if (tval <= tc)
         {
             SATTdll(&tval, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
-            if (ierr != 0) {
+            if (ierr > 0) {
                 if ((ierr == 1) || (ierr == 9) || (ierr == 121))
                     return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit
                 else if (ierr == 8)
@@ -70,11 +70,11 @@ LRESULT rp_Sth(
     // REFPROP 10 Issue: Single-phase root confusion when T = Tc exactly
     // As a workaround, adjust tval slightly if Tc passed in
     CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(UNCONVERGED, 1);
     if (tval == tc) tval = tval + 0.0001;
 
-	sval = 0.0;
+    sval = 0.0;
 
     THFLSHdll(&tval, &hval, &x[0], &kr, &pval, &dval, &rhol, &rhov, &xliq[0], &xvap[0], &qval,
                 &uval, &sval, &cv, &cp, &wval, &ierr, herr, errormessagelength);
@@ -90,8 +90,8 @@ LRESULT rp_Sth(
             return MAKELRESULT(UNCONVERGED, 1);
     }
 
-	// Otherwise...
-	ret->real = sval / wmm;       // Returned in kJ/kg-K
+    // Otherwise...
+    ret->real = sval / wmm;       // Returned in kJ/kg-K
 
     return 0;                     // return 0 to indicate there was no error
             
@@ -102,12 +102,12 @@ FUNCTIONINFO    rp_sth =
     (char *)("rp_sth"),                 // Name by which mathcad will recognize the function
     (char *)("fluid,p,h,r"),            // rp_sth will be called as rp_sth(fluid,t,h,r)
     (char *)("Returns the Entropy [kJ/kg-K] given the pressure [MPa] and enthalpy [kJ/kg]"),
-										// description of rp_sth(fluid,t,h,r)
+                                        // description of rp_sth(fluid,t,h,r)
     (LPCFUNCTION)rp_Sth,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     4,                                  // the function takes on 4 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };

--- a/wrappers/Mathcad/includes/rp_stp.h
+++ b/wrappers/Mathcad/includes/rp_stp.h
@@ -4,28 +4,28 @@ LRESULT rp_Stp(
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      p   )
 {
-	double tval,pval,Dval;
+    double tval,pval,Dval;
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
     double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real;
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real;
 
     if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
@@ -35,8 +35,8 @@ LRESULT rp_Stp(
     // Get critical pressure
     if (ncomp > 1)
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr > 0)
         {
             return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -81,7 +81,7 @@ LRESULT rp_Stp(
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
     }
 
-	ret->real = S/wmm;   // Convert from J/mol-K to kJ/kg-K
+    ret->real = S/wmm;   // Convert from J/mol-K to kJ/kg-K
 
     return 0;               // return 0 to indicate there was no error
             
@@ -92,14 +92,11 @@ FUNCTIONINFO    rp_stp =
     (char *)("rp_stp"),                 // Name by which Mathcad will recognize the function
     (char *)("fluid,t,p"),              // rp_stp will be called as rp_stp(fluid,t,p)
     (char *)("Returns the entropy [kJ/kg-K] given the temperature [K] and pressure [MPa]"),
-										// description of rp_stp(fluid,t,p)
+                                        // description of rp_stp(fluid,t,p)
     (LPCFUNCTION)rp_Stp,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
-    
-    
-    

--- a/wrappers/Mathcad/includes/rp_strho.h
+++ b/wrappers/Mathcad/includes/rp_strho.h
@@ -8,7 +8,7 @@ LRESULT rp_Strho(
 	int ierr;
 
     ierr = cSetup(fluid->str);
-    if (ierr != 0)
+    if (ierr > 0)
         return MAKELRESULT(ierr, 1);
 
     if (t->imag != 0.0)

--- a/wrappers/Mathcad/includes/rp_surften.h
+++ b/wrappers/Mathcad/includes/rp_surften.h
@@ -9,7 +9,7 @@ LRESULT rp_Surften(
 	double psat,tsat,rhol,rhov,xliq[20],xvap[20],sigma;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -19,7 +19,7 @@ LRESULT rp_Surften(
 		
 	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,xliq,xvap,&ierr,herr,errormessagelength);
 
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 1) || (ierr == 9) || (ierr == 121))
             return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit
@@ -31,7 +31,7 @@ LRESULT rp_Surften(
 
 	SURTENdll(&tsat, &rhol, &rhov, &xliq[0], &xvap[0], &sigma, &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_tcrit.h
+++ b/wrappers/Mathcad/includes/rp_tcrit.h
@@ -3,52 +3,52 @@ LRESULT rp_Tcrit(
     LPCMCSTRING       fluid,
     LPCCOMPLEXSCALAR   comp   )
 {
-	char herr[255];
+    char herr[255];
     unsigned int lherr = 255;
-	int ierr = 0;
-	int icomp = 1;
-	double wmm, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas; 
+    int ierr = 0;
+    int icomp = 1;
+    double wmm, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas; 
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( comp->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		icomp = static_cast<int>(comp->real);
-	
-	if ((icomp > ncomp)||(icomp < 0))
-		return MAKELRESULT(BAD_COMPONENT,2);
-	else if ((icomp == 0)&&(ncomp > 1))
-	{
-		CRITPdll(&x[0],&tc,&pc,&Dc,&ierr,herr,lherr);
-		if (ierr != 0)
-		{
-			return MAKELRESULT(UNCONVERGED,2);
-		}
-	}
-	else 
-	{
-		if (icomp == 0) icomp = 1;
-		INFOdll(&icomp,&wmm,&ttrip,&tnbpt,&tc,&pc,&Dc,&Zc,&acf,&dip,&Rgas);
-	}
-		
-	ret->real = tc;
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        icomp = static_cast<int>(comp->real);
+    
+    if ((icomp > ncomp)||(icomp < 0))
+        return MAKELRESULT(BAD_COMPONENT,2);
+    else if ((icomp == 0)&&(ncomp > 1))
+    {
+        CRITPdll(&x[0],&tc,&pc,&Dc,&ierr,herr,lherr);
+        if (ierr > 0)
+        {
+            return MAKELRESULT(UNCONVERGED,2);
+        }
+    }
+    else 
+    {
+        if (icomp == 0) icomp = 1;
+        INFOdll(&icomp,&wmm,&ttrip,&tnbpt,&tc,&pc,&Dc,&Zc,&acf,&dip,&Rgas);
+    }
+        
+    ret->real = tc;
 
     return 0;               // return 0 to indicate there was no error
-            
-}           
+
+}
 
     FUNCTIONINFO    rp_tcrit = 
 { 
     (char *)("rp_tcrit"),               // Name by which Mathcad will recognize the function
     (char *)("fluid,comp"),             // rp_tcrit will be called as rp_tcrit(fluid,comp)
     (char *)("Returns molecular weight [g/mol] of the component number specified"),
-										// description of rp_tcrit(fluid,comp)
+                                        // description of rp_tcrit(fluid,comp)
     (LPCFUNCTION)rp_Tcrit,              // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes on 1 argument
     { MC_STRING,
-	  COMPLEX_SCALAR }                  // argument is a complex scalar
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };

--- a/wrappers/Mathcad/includes/rp_ths.h
+++ b/wrappers/Mathcad/includes/rp_ths.h
@@ -11,7 +11,7 @@ LRESULT rp_Ths(
 	int kph = 1;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 
     if( h->imag != 0.0 )
@@ -27,7 +27,7 @@ LRESULT rp_Ths(
 	// Use the full HSFLSH function
 
 	HSFLSHdll(&hval, &sval, &x[0], &tval, &pval, &dval, &rhol, &rhov, &xliq[0], &xvap[0], &qual, &eval, &Cv, &Cp, &wval, &ierr, herr, errormessagelength);
-    if (ierr != 0)
+    if (ierr > 0)
     {
         if ((ierr == 4) || (ierr == 12))
             return MAKELRESULT(P_OUT_OF_RANGE, 1);

--- a/wrappers/Mathcad/includes/rp_tmax.h
+++ b/wrappers/Mathcad/includes/rp_tmax.h
@@ -5,7 +5,7 @@ LRESULT rp_Tmax(
 	int ierr = 0;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 
     ret->real = Tmax;

--- a/wrappers/Mathcad/includes/rp_tmin.h
+++ b/wrappers/Mathcad/includes/rp_tmin.h
@@ -5,7 +5,7 @@ LRESULT rp_Tmin(
 	int ierr = 0;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 
     ret->real = Tmin;

--- a/wrappers/Mathcad/includes/rp_tph.h
+++ b/wrappers/Mathcad/includes/rp_tph.h
@@ -4,67 +4,67 @@ LRESULT rp_Tph(
     LPCCOMPLEXSCALAR      p,
     LPCCOMPLEXSCALAR      h   )
 {
-	char herr[255];
-	double pval,hval,dval,tval;
-	double pc,tc,Dc,hc;
-	double tsat,rhol,rhov,xliq[20],xvap[20],hliq,hvap;
-	int ierr;
-	int kph = 1;             // initialize to Liquid
+    char herr[255];
+    double pval,hval,dval,tval;
+    double pc,tc,Dc,hc;
+    double tsat,rhol,rhov,xliq[20],xvap[20],hliq,hvap;
+    int ierr;
+    int kph = 1;             // initialize to Liquid
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		pval = p->real * 1000.0;  // Convert from MPa to kPa
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        pval = p->real * 1000.0;  // Convert from MPa to kPa
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 2);
 
     if( h->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		hval = h->real * wmm;     // Convert from kJ/kg to J/mol
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        hval = h->real * wmm;     // Convert from kJ/kg to J/mol
 
-	// Are we above the critical pressure?
-	CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-	if (ierr > 0)
-		return MAKELRESULT(UNCONVERGED,1);
+    // Are we above the critical pressure?
+    CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+    if (ierr > 0)
+        return MAKELRESULT(UNCONVERGED,1);
 
-	if (pval < pc)
-	{
-		// Below the critical pressure
-		SATPdll(&pval, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
-		if (ierr > 0)
-		{
-			if ((ierr == 2)||(ierr == 4)||(ierr == 141)) 
-				return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
-			else
-				return MAKELRESULT(UNCONVERGED,2); // failed to converge
-		}
-		ENTHALdll(&tsat, &rhol, &x[0], &hliq);         // Get Saturated Liquid Enthalpy at P
-		ENTHALdll(&tsat, &rhov, &x[0], &hvap);         // Get Saturated Vapor Enthalpy at P
-		if ((hval >= hliq) && (hval <= hvap))
-		{                                    // within saturation curve
-			ret->real = tsat;                // return the saturation temperature
-			return 0;
-		}
-		if (hval < hliq)                     // below liquid enthalpy
-		{                                    // initialize...
-			kph = 1;                         //    liquid phase
-			tval = tsat;                     //    saturation temp
-			dval = rhol;                     //    saturation density
-		}
-		else                                 // above vapor enthalpy
-		{                                    // initialize...
-			kph = 2;                         //    vapor phase
-			tval = tsat;                     //    saturation temp
-			dval = rhov;                     //    saturation density
-		}
-		PHFL1dll(&pval, &hval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
-		if (ierr > 0)
-			return MAKELRESULT(UNCONVERGED,2);
+    if (pval < pc)
+    {
+        // Below the critical pressure
+        SATPdll(&pval, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
+        if (ierr > 0)
+        {
+            if ((ierr == 2)||(ierr == 4)||(ierr == 141)) 
+                return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
+            else
+                return MAKELRESULT(UNCONVERGED,2); // failed to converge
+        }
+        ENTHALdll(&tsat, &rhol, &x[0], &hliq);         // Get Saturated Liquid Enthalpy at P
+        ENTHALdll(&tsat, &rhov, &x[0], &hvap);         // Get Saturated Vapor Enthalpy at P
+        if ((hval >= hliq) && (hval <= hvap))
+        {                                    // within saturation curve
+            ret->real = tsat;                // return the saturation temperature
+            return 0;
+        }
+        if (hval < hliq)                     // below liquid enthalpy
+        {                                    // initialize...
+            kph = 1;                         //    liquid phase
+            tval = tsat;                     //    saturation temp
+            dval = rhol;                     //    saturation density
+        }
+        else                                 // above vapor enthalpy
+        {                                    // initialize...
+            kph = 2;                         //    vapor phase
+            tval = tsat;                     //    saturation temp
+            dval = rhov;                     //    saturation density
+        }
+        PHFL1dll(&pval, &hval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
+        if (ierr > 0)
+            return MAKELRESULT(UNCONVERGED,2);
     }
     else {                                      // above critical pressure
         kph = 2;                                // use vapor iterations
@@ -78,7 +78,7 @@ LRESULT rp_Tph(
             return MAKELRESULT(UNCONVERGED, 3);
     }
 
-	ret->real = tval;       // Returned in degrees K
+    ret->real = tval;       // Returned in degrees K
 
     return 0;               // return 0 to indicate there was no error
             
@@ -89,13 +89,13 @@ FUNCTIONINFO    rp_tph =
     (char *)("rp_tph"),                 // Name by which mathcad will recognize the function
     (char *)("fluid,p,h"),              // rp_tph will be called as rp_tph(fluid,p,h)
     (char *)("Returns the temperature [K] given the pressure [MPa] and enthalpy [kJ/kg]"),
-										// description of rp_tph(fluid,p,h)
+                                        // description of rp_tph(fluid,p,h)
     (LPCFUNCTION)rp_Tph,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes 3 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
     
     

--- a/wrappers/Mathcad/includes/rp_tps.h
+++ b/wrappers/Mathcad/includes/rp_tps.h
@@ -4,67 +4,67 @@ LRESULT rp_Tps(
     LPCCOMPLEXSCALAR      p,
     LPCCOMPLEXSCALAR      s   )
 {
-	char herr[255];
-	double pval,sval,dval,tval;
-	double pc,tc,Dc,sc;
-	double tsat,rhol,rhov,xliq[20],xvap[20],sliq,svap;
-	int ierr;
-	int kph = 1;               // initialize to liquid
+    char herr[255];
+    double pval,sval,dval,tval;
+    double pc,tc,Dc,sc;
+    double tsat,rhol,rhov,xliq[20],xvap[20],sliq,svap;
+    int ierr;
+    int kph = 1;               // initialize to liquid
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		pval = p->real * 1000.0;  // Convert from MPa to kPa
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        pval = p->real * 1000.0;  // Convert from MPa to kPa
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 2);
 
     if( s->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		sval = s->real * wmm;  // Convert from kJ/kg-K to J/mol-K
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        sval = s->real * wmm;  // Convert from kJ/kg-K to J/mol-K
 
-	// Are we above the critical pressure?
-	CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-	if (ierr != 0)
-		return MAKELRESULT(UNCONVERGED,2);
+    // Are we above the critical pressure?
+    CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+    if (ierr > 0)
+        return MAKELRESULT(UNCONVERGED,2);
 
-	if (pval < pc)
-	{
-		// Below the critical pressure
-		SATPdll(&pval, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
-		if (ierr != 0)
-		{
-			if ((ierr == 2)||(ierr == 4)||(ierr == 141)) 
-				return MAKELRESULT(4,1); // Pressure too low | negative | > Pcrit
-			else
-				return MAKELRESULT(9,1); // failed to converge
-		}
-		ENTROdll(&tsat, &rhol, &x[0], &sliq); // Get Saturated Liquid Entropy at P
-		ENTROdll(&tsat, &rhov, &x[0], &svap); // Get Saturated Vapor Entropy at P
-		if ((sval >= sliq)&&(sval <= svap))
-		{                                     // within saturation curve
-			ret->real = tsat;                 // return the saturation temperature
-			return 0;
-		}
-		if (sval < sliq)                      // below liquid entropy
-		{                                     // initialize...
-			kph = 1;                          //    liquid phase
-			tval = tsat;                      //    saturation temp
-			dval = rhol;                      //    saturation density
-		}
-		else                                  // above vapor entropy
-		{                                     // initialize...
-			kph = 2;                          //    vapor phase
-			tval = tsat;                      //    saturation temp
-			dval = rhov;                      //    saturation density
-		}
-		PSFL1dll(&pval, &sval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
-		if (ierr != 0)
-			return MAKELRESULT(UNCONVERGED,3);
+    if (pval < pc)
+    {
+        // Below the critical pressure
+        SATPdll(&pval, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
+        if (ierr > 0)
+        {
+            if ((ierr == 2)||(ierr == 4)||(ierr == 141)) 
+                return MAKELRESULT(4,1); // Pressure too low | negative | > Pcrit
+            else
+                return MAKELRESULT(9,1); // failed to converge
+        }
+        ENTROdll(&tsat, &rhol, &x[0], &sliq); // Get Saturated Liquid Entropy at P
+        ENTROdll(&tsat, &rhov, &x[0], &svap); // Get Saturated Vapor Entropy at P
+        if ((sval >= sliq)&&(sval <= svap))
+        {                                     // within saturation curve
+            ret->real = tsat;                 // return the saturation temperature
+            return 0;
+        }
+        if (sval < sliq)                      // below liquid entropy
+        {                                     // initialize...
+            kph = 1;                          //    liquid phase
+            tval = tsat;                      //    saturation temp
+            dval = rhol;                      //    saturation density
+        }
+        else                                  // above vapor entropy
+        {                                     // initialize...
+            kph = 2;                          //    vapor phase
+            tval = tsat;                      //    saturation temp
+            dval = rhov;                      //    saturation density
+        }
+        PSFL1dll(&pval, &sval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
+        if (ierr > 0)
+            return MAKELRESULT(UNCONVERGED,3);
     }
     else
     {                                          // above critical pressure
@@ -75,11 +75,11 @@ LRESULT rp_Tps(
         if (sval < sc / 2.0) tval = tc * 0.8;  //   if very low entropy, reduce t guess
 
         PSFL1dll(&pval, &sval, &x[0], &kph, &tval, &dval, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        if (ierr > 0)
             return MAKELRESULT(UNCONVERGED, 3);
     }
 
-	ret->real = tval;       // Returned in degrees K
+    ret->real = tval;       // Returned in degrees K
 
     return 0;               // return 0 to indicate there was no error
             
@@ -90,12 +90,12 @@ FUNCTIONINFO    rp_tps =
     (char *)("rp_tps"),                 // Name by which mathcad will recognize the function
     (char *)("fluid,p,s"),              // rp_tps will be called as rp_tps(fluid,p,s)
     (char *)("Returns the temperature [K] given the pressure [MPa] and entropy [kJ/kg-K]"),
-										// description of rp_tps(fluid,p,s)
+                                        // description of rp_tps(fluid,p,s)
     (LPCFUNCTION)rp_Tps,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 2 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
     

--- a/wrappers/Mathcad/includes/rp_tsatp.h
+++ b/wrappers/Mathcad/includes/rp_tsatp.h
@@ -9,7 +9,7 @@ LRESULT rp_Tsatp(
 	double psat,tsat,rhol,rhov,xliq[20],xvap[20];
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -19,7 +19,7 @@ LRESULT rp_Tsatp(
 		
 	SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2)||(ierr == 4)||(ierr == 12)||(ierr == 141)) 
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_ttrip.h
+++ b/wrappers/Mathcad/includes/rp_ttrip.h
@@ -13,7 +13,7 @@ LRESULT rp_Ttrip(
 	double tmax,Dmax,pmax;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 
     if( comp->imag != 0.0 )

--- a/wrappers/Mathcad/includes/rp_ufp.h
+++ b/wrappers/Mathcad/includes/rp_ufp.h
@@ -10,7 +10,7 @@ LRESULT rp_Ufp(
     double U, H, S, Cv, Cp, W, hjt;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Ufp(
 
 	SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_uft.h
+++ b/wrappers/Mathcad/includes/rp_uft.h
@@ -10,7 +10,7 @@ LRESULT rp_Uft(
     double U, H, S, Cv, Cp, W, hjt;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Uft(
 
 	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_ugp.h
+++ b/wrappers/Mathcad/includes/rp_ugp.h
@@ -10,7 +10,7 @@ LRESULT rp_Ugp(
     double U, H, S, Cv, Cp, W, hjt;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Ugp(
 
 	SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_ugt.h
+++ b/wrappers/Mathcad/includes/rp_ugt.h
@@ -10,7 +10,7 @@ LRESULT rp_Ugt(
 	double U, H, S, Cv, Cp, W, hjt;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Ugt(
 
 	SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_utp.h
+++ b/wrappers/Mathcad/includes/rp_utp.h
@@ -4,28 +4,28 @@ LRESULT rp_Utp(
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      p   )
 {
-	double tval,pval,Dval;
+    double tval,pval,Dval;
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
     double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real;
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real;
 
     if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
@@ -35,8 +35,8 @@ LRESULT rp_Utp(
     // Get critical pressure
     if (ncomp > 1)
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr > 0)
         {
             return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -86,7 +86,7 @@ LRESULT rp_Utp(
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
     }
 
-	ret->real = U/wmm;   // Convert from J/mol to kJ/kg
+    ret->real = U/wmm;   // Convert from J/mol to kJ/kg
 
     return 0;               // return 0 to indicate there was no error
             
@@ -97,14 +97,11 @@ FUNCTIONINFO    rp_utp =
     (char *)("rp_utp"),                 // Name by which Mathcad will recognize the function
     (char *)("fluid,t,p"),              // rp_utp will be called as rp_utp(fluid,t,p)
     (char *)("Returns the internal energy [kJ/kg] given the temperature [K] and pressure [MPa]"),
-										// description of rp_utp(fluid,t,p)
+                                        // description of rp_utp(fluid,t,p)
     (LPCFUNCTION)rp_Utp,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
-    
-    
-    

--- a/wrappers/Mathcad/includes/rp_wfp.h
+++ b/wrappers/Mathcad/includes/rp_wfp.h
@@ -10,7 +10,7 @@ LRESULT rp_Wfp(
     double U, H, S, Cv, Cp, W, hjt;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Wfp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_wft.h
+++ b/wrappers/Mathcad/includes/rp_wft.h
@@ -10,7 +10,7 @@ LRESULT rp_Wft(
     double U, H, S, Cv, Cp, W, hjt;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Wft(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_wgp.h
+++ b/wrappers/Mathcad/includes/rp_wgp.h
@@ -10,7 +10,7 @@ LRESULT rp_Wgp(
     double U, H, S, Cv, Cp, W, hjt;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( p->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Wgp(
 
     SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141))
 			return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit

--- a/wrappers/Mathcad/includes/rp_wgt.h
+++ b/wrappers/Mathcad/includes/rp_wgt.h
@@ -10,7 +10,7 @@ LRESULT rp_Wgt(
 	double U, H, S, Cv, Cp, W, hjt;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 	
     if( t->imag != 0.0 )
@@ -20,7 +20,7 @@ LRESULT rp_Wgt(
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
-	if (ierr != 0)
+	if (ierr > 0)
 	{
 		if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
 			return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit

--- a/wrappers/Mathcad/includes/rp_wmol.h
+++ b/wrappers/Mathcad/includes/rp_wmol.h
@@ -3,13 +3,13 @@ LRESULT rp_Wmol(
     LPCMCSTRING       fluid,
     LPCCOMPLEXSCALAR   comp   )
 {
-	int icomp,ierr;
-	double wmm0, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    int icomp,ierr;
+    double wmm0, ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
 
     std::string strFluid = fluid->str;
-	ierr = cSetup(strFluid);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(strFluid);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if (comp->imag != 0.0)
         return MAKELRESULT(MUST_BE_REAL, 2);
@@ -17,7 +17,7 @@ LRESULT rp_Wmol(
         icomp = static_cast<int>(comp->real);
 
     if((icomp > ncomp)||(icomp < 0))
-		return 	MAKELRESULT(BAD_COMPONENT,2);   // Invalid component number
+        return 	MAKELRESULT(BAD_COMPONENT,2);   // Invalid component number
 
     if ((icomp == 0) && (ncomp > 1))
         wmm0 = wmm;         // this is the mixture molecular wt.
@@ -27,7 +27,7 @@ LRESULT rp_Wmol(
         INFOdll(&icomp, &wmm0, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
     }
 
-	ret->real = wmm0;
+    ret->real = wmm0;
 
     return 0;               // return 0 to indicate there was no error
             
@@ -38,11 +38,10 @@ FUNCTIONINFO    rp_wmol =
     (char *)("rp_wmol"),                // Name by which Mathcad will recognize the function
     (char *)("fluid,comp"),             // rp_wmol will be called as rp_wmol(fluid,comp)
     (char *)("Returns molecular weight [g/mol] of the component number specified"),
-										// description of rp_wmol(fluid,comp)
+                                        // description of rp_wmol(fluid,comp)
     (LPCFUNCTION)rp_Wmol,               // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes two arguments
     { MC_STRING,                        // first argument is an MC_STRING
-	  COMPLEX_SCALAR }                  // second argument is a complex scalar
+      COMPLEX_SCALAR }                  // second argument is a complex scalar
 };
-    

--- a/wrappers/Mathcad/includes/rp_wtp.h
+++ b/wrappers/Mathcad/includes/rp_wtp.h
@@ -4,28 +4,28 @@ LRESULT rp_Wtp(
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      p   )
 {
-	double tval,pval,Dval;
+    double tval,pval,Dval;
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
     double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
 
-	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
-		return MAKELRESULT(ierr,1);
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,2);
-	else
-		tval = t->real;
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tval = t->real;
 
     if (tval > Tmax*(1 + 0.5*extr)) return MAKELRESULT(T_OUT_OF_RANGE, 2);
 
     if( p->imag != 0.0 )
-		return MAKELRESULT(MUST_BE_REAL,3);
-	else
-		pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
+        return MAKELRESULT(MUST_BE_REAL,3);
+    else
+        pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
@@ -35,8 +35,8 @@ LRESULT rp_Wtp(
     // Get critical pressure
     if (ncomp > 1)
     {
-        CRITPdll(x, &tc, &pc, &Dc, &ierr, herr, errormessagelength);
-        if (ierr != 0)
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, errormessagelength);
+        if (ierr > 0)
         {
             return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -81,7 +81,7 @@ LRESULT rp_Wtp(
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
     }
 
-	ret->real = W;
+    ret->real = W;
 
     return 0;               // return 0 to indicate there was no error
             
@@ -92,14 +92,11 @@ FUNCTIONINFO    rp_wtp =
     (char *)("rp_wtp"),                 // Name by which Mathcad will recognize the function
     (char *)("fluid,t,p"),              // rp_wtp will be called as rp_wtp(fluid,t,p)
     (char *)("Returns the speed of sound [m/s] given the temperature [K] and pressure [MPa]"),
-										// description of rp_wtp(fluid,t,p)
+                                        // description of rp_wtp(fluid,t,p)
     (LPCFUNCTION)rp_Wtp,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument
-	  COMPLEX_SCALAR,
-	  COMPLEX_SCALAR }                  // arguments are complex scalars
+      COMPLEX_SCALAR,
+      COMPLEX_SCALAR }                  // arguments are complex scalars
 };
-    
-    
-    

--- a/wrappers/Mathcad/includes/rp_wtrho.h
+++ b/wrappers/Mathcad/includes/rp_wtrho.h
@@ -9,7 +9,7 @@ LRESULT rp_Wtrho(
 	int ierr;
 
 	ierr = cSetup(fluid->str);
-	if (ierr != 0 )
+	if (ierr > 0)
 		return MAKELRESULT(ierr,1);
 
     if( t->imag != 0.0 )

--- a/wrappers/Mathcad/src/Refprop.cpp
+++ b/wrappers/Mathcad/src/Refprop.cpp
@@ -53,7 +53,7 @@ enum { MC_STRING = STRING }; // Substitute enumeration variable MC_STRING for ST
 #include <fstream>
 
 // RefProp Mathcad Add-in Version
-std::string rpVersion = "2.0.1";       // Mathcad Add-in version number
+std::string rpVersion = "2.0.2";       // Mathcad Add-in version number
 
 // Setup Dialog Window for debugging
 HWND hwndDlg;  // Dialog handle for pop-up message boxes
@@ -65,7 +65,7 @@ enum EC {MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,                  //
          NO_SURFTEN, H_OUT_OF_RANGE, S_OUT_OF_RANGE,
          D_OUT_OF_RANGE, BAD_INPUT, INVALID_FLAG, X_SUM_NONUNITY,
          NO_UPPER_ROOT, TOO_MANY_COMPONENTS, BAD_MIX_STRING,
-         BAD_MOLE_FRACTION, INDIV_COMPONENT, UNKNOWN,
+         BAD_MOLE_FRACTION, INDIV_COMPONENT, SATSPLN_FAILED, UNKNOWN,
          NUMBER_OF_ERRORS};                                                   // Dummy code for Error Count
 
 // This is the list of errors that can be output if any of the functions fails.
@@ -97,6 +97,7 @@ char * RPErrorMessageTable[NUMBER_OF_ERRORS] =
     (char *)("Bad mixture string format: c1[mf1]&c2[mf2]...&cX[mfX]"),   // BAD_MIX_STRING
     (char *)("Mole fraction can't be converted"),           //  BAD_MOLE_FRACTION
     (char *)("Must specify individual component number"),   //  INDIV_COMPONENT
+    (char *)("Saturation routine failed for mixture"),      //  SATSPLN_FAILED
     (char *)("Unknown Error"),                              //  UNKNOWN
     (char *)("Error Count - Not Used")                      //  NUMBER_OF_ERRORS
 };
@@ -112,7 +113,7 @@ double Pmax;                          // Max Pressure
 double wmm;                           // Molar Mass
 std::string err;                      // error string from REFPROP load DLL
 std::string MixFileName;              // Mixture File Name Storage
-std::string MixFileLast = "";         // Mixture File Name Storage
+std::string LastFluid = "";           // Mixture File Name Storage
 std::string fluidPath;
 char MixName[namelengthlong+1];       // Mixture Name from loaded mixture file.
 


### PR DESCRIPTION
### Description of the Change

Fixes two issues that were occurring in the Mathcad wrapper interface:

1. Previous patch exposed a bug in the wrapper when calling CRITPdll for mixtures.  Two changes made to correct this issue:
    - Calls to CRITPdll checked for (ierr != 0), which failed when REFPROP returned warnings.  Changed this to check for (ierr > 0) when throwing an error to ignore REFPROP warnings (negative ierr return values).  Changed this behavior for ALL instances of (ierr != 0) in the wrapper code as a best practice. 
    - Modified passing of mole fraction array variable, `x`, to be consistent with other pass-by-reference instances using `&x[0]` for consistency.
2. Mathcad wrapper now checks for .MIX files in the default MIXTURES directory.  If not found, tries to locate the .MIX file in the user's Virtual Store where the REFPROP GUI stores it when it can't write to the C: drive.

**Additional Items:**
- When loading new fluids, if number of components is greater than 1 (mixture), SATSPLN is called by default, consistent with the behavior of the REFPROP GUI.
- Converted tab characters to spaces (untabify) in many files changed for this patch for clearer viewing on Github
- Created additional project configurations in the VS script to simplify building for Mathcad Prime versions 5, 6, 7, and 8.
- Updated wrapper version to patch version 2.0.2.

### Benefits

1. Mixture property calls now behave as expected.
5. SATSPLN now called by default when new mixtures are loaded for better saturation curve behavior
6. Custom mixtures created by the REFPROP GUI are now found in the user's Virtual Store if REFPROP can't save the custom mixture to the user's C: drive.

### Possible Drawbacks

SATSPLNdll is now called by default on the legacy function calls whenever a new mixture fluid is loaded (ncomp > 1).    This is the default behavior for the REFPROP GUI.  However, there may be fluid mixtures that do not benefit from the spline calls or there may be situations where the splines are not desired.  Potentially, a Mathcad wrapper function could be created that would set a flag to disable this default behavior if needed.

Lots of files changed in this PR due to "untabify" operation on files being worked on.  Will untabify the remaining files in a separate PR to keep future code mod PR's cleaner.

### Verification Process

- Tested new functionality and proper mixture calculations with SATSPLN called by default.
- Ran extended regression testing that now includes mixture behavior.
- Test proper retrieval of standard pre-defined mixtures as well as custom mixture files stored in user's Virtual Store. 

### Applicable Issues (none)

Closes #464 
Closes #465 