### PR TITLE
Remove FMTLIB submodule from Repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "externals/REFPROP-cmake"]
 	path = externals/REFPROP-cmake
 	url = https://github.com/usnistgov/REFPROP-cmake
-[submodule "wrappers/Mathcad/externals/fmtlib"]
-	path = externals/fmtlib
-	url = https://github.com/fmtlib/fmt.git


### PR DESCRIPTION
### Description of the Change

Remove the externals/fmtlib sub-module from the REFPROP-wrappers repository.

### Benefits

- Was introduced with the upload of the Mathcad wrapper, but is no longer needed after update in #470 

### Possible Drawbacks

- Only if any other wrappers started using it, but this is doubtful.

### Verification Process

- Ran extended regression testing successfully in #470 with externals/fmtlib removed from build. 

### Applicable Issues (none)
