### PR TITLE
Add derived quantity functions to Mathcad wrapper

### DIFF
--- a/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.vcxproj
+++ b/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.vcxproj
@@ -49,6 +49,11 @@
   <ItemGroup>
     <ClInclude Include="..\..\..\externals\REFPROP-headers\REFPROP_lib.h" />
     <ClInclude Include="..\includes\RPstrings.h" />
+    <ClInclude Include="..\includes\rp_betafp.h" />
+    <ClInclude Include="..\includes\rp_betaft.h" />
+    <ClInclude Include="..\includes\rp_betagp.h" />
+    <ClInclude Include="..\includes\rp_betagt.h" />
+    <ClInclude Include="..\includes\rp_betatp.h" />
     <ClInclude Include="..\includes\rp_cpfp.h" />
     <ClInclude Include="..\includes\rp_cpft.h" />
     <ClInclude Include="..\includes\rp_cpgp.h" />
@@ -61,10 +66,16 @@
     <ClInclude Include="..\includes\rp_cvtp.h" />
     <ClInclude Include="..\includes\rp_cvtrho.h" />
     <ClInclude Include="..\includes\rp_extrapolate.h" />
+    <ClInclude Include="..\includes\rp_gammafp.h" />
+    <ClInclude Include="..\includes\rp_gammaft.h" />
+    <ClInclude Include="..\includes\rp_gammagp.h" />
+    <ClInclude Include="..\includes\rp_gammagt.h" />
+    <ClInclude Include="..\includes\rp_gammatp.h" />
     <ClInclude Include="..\includes\rp_getcasn.h" />
     <ClInclude Include="..\includes\rp_getname.h" />
     <ClInclude Include="..\includes\rp_getNIST.h" />
     <ClInclude Include="..\includes\rp_getpath.h" />
+    <ClInclude Include="..\includes\rp_getRPnum.h" />
     <ClInclude Include="..\includes\rp_getvers.h" />
     <ClInclude Include="..\includes\rp_hfp.h" />
     <ClInclude Include="..\includes\rp_hft.h" />
@@ -87,6 +98,11 @@
     <ClInclude Include="..\includes\rp_pcrit.h" />
     <ClInclude Include="..\includes\rp_phs.h" />
     <ClInclude Include="..\includes\rp_pmax.h" />
+    <ClInclude Include="..\includes\rp_prfp.h" />
+    <ClInclude Include="..\includes\rp_prft.h" />
+    <ClInclude Include="..\includes\rp_prgp.h" />
+    <ClInclude Include="..\includes\rp_prgt.h" />
+    <ClInclude Include="..\includes\rp_prtp.h" />
     <ClInclude Include="..\includes\rp_psatt.h" />
     <ClInclude Include="..\includes\rp_pth.h" />
     <ClInclude Include="..\includes\rp_ptrho.h" />
@@ -133,6 +149,12 @@
     <ClInclude Include="..\includes\rp_wmol.h" />
     <ClInclude Include="..\includes\rp_wtp.h" />
     <ClInclude Include="..\includes\rp_wtrho.h" />
+    <ClInclude Include="..\includes\rp_zcrit.h" />
+    <ClInclude Include="..\includes\rp_zfp.h" />
+    <ClInclude Include="..\includes\rp_zft.h" />
+    <ClInclude Include="..\includes\rp_zgp.h" />
+    <ClInclude Include="..\includes\rp_zgt.h" />
+    <ClInclude Include="..\includes\rp_ztp.h" />
     <ClInclude Include="..\includes\setup.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.vcxproj.filters
+++ b/wrappers/Mathcad/buildPrime/RefpropPrimeWrapper.vcxproj.filters
@@ -266,6 +266,72 @@
     <ClInclude Include="..\includes\setup.h">
       <Filter>includes</Filter>
     </ClInclude>
+    <ClInclude Include="..\includes\rp_betatp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_gammatp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_gammafp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_gammaft.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_gammagp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_gammagt.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_betafp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_betaft.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_betagp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_betagt.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_prtp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_prfp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_prft.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_prgp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_prgt.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_zcrit.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_zfp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_zft.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_zgp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_zgt.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_ztp.h">
+      <Filter>includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\rp_getRPnum.h">
+      <Filter>includes</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="includes">

--- a/wrappers/Mathcad/includes/rp_betafp.h
+++ b/wrappers/Mathcad/includes/rp_betafp.h
@@ -1,0 +1,55 @@
+LRESULT rp_Bfp(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      p   )
+{
+    char herr[255];
+    int kph = 1;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
+    int ierr;
+    double psat,tsat,rhol,rhov,xliq[20],xvap[20];
+    double xkappa, beta = 0.0, xisenk, xkt, betas, bs, xkkt, thrott, pi, spht;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+
+    if( p->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        psat = p->real * 1000.0;
+
+    SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
+            return MAKELRESULT(P_OUT_OF_RANGE, 2); // Pressure too low | negative | > Pcrit
+        else if (ierr == 8)
+            return MAKELRESULT(X_SUM_NONUNITY, 1);
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    THERM3dll(&tsat, &rhol, &x[0], &xkappa,
+        &beta,                                // Volume expansion coefficient (= 1/rho dD/dT) [1/K]
+        &xisenk, &xkt, &betas, &bs, &xkkt,
+        &thrott, &pi, &spht);
+
+    ret->real = beta;       // Return thermal expansion coefficient [1/K]
+
+    return 0;               // return 0 to indicate there was no error
+
+}
+
+FUNCTIONINFO    rp_betafp =
+{
+    (char *)("rp_betafp"),              // Name by which mathcad will recognize the function
+    (char *)("fluid,p"),                // rp_betafp will be called as rp_betafp(fluid,p)
+    (char *)("Returns the saturation liquid volume expansion coefficient [1/K] given the pressure [MPa]"),
+                                        // description of rp_betafp(fluid,p)
+    (LPCFUNCTION)rp_Bfp,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};

--- a/wrappers/Mathcad/includes/rp_betaft.h
+++ b/wrappers/Mathcad/includes/rp_betaft.h
@@ -1,0 +1,54 @@
+LRESULT rp_Bft(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      t   )
+{
+    char herr[255];
+    int kph = 1;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)  
+    int ierr;
+    double psat,tsat,rhol,rhov,xliq[20],xvap[20];
+    double xkappa, beta = 0.0, xisenk, xkt, betas, bs, xkkt, thrott, pi, spht;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( t->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tsat = t->real;
+
+    SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
+            return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    THERM3dll(&tsat, &rhol, &x[0], &xkappa,
+        &beta,                                // Volume expansion coefficient (= 1/rho dD/dT) [1/K]
+        &xisenk, &xkt, &betas, &bs, &xkkt,
+        &thrott, &pi, &spht);
+
+    ret->real = beta;       // Return thermal expansion coefficient [1/K]
+
+    return 0;               // return 0 to indicate there was no error
+            
+}    
+
+FUNCTIONINFO    rp_betaft = 
+{ 
+    (char *)("rp_betaft"),              // Name by which mathcad will recognize the function
+    (char *)("fluid,t"),                // rp_betaft will be called as rp_betaft(fluid,t)
+    (char *)("Returns the saturation liquid volume expansion coefficient [1/K] given the temperature [K]"),
+                                        // description of rp_betaft(fluid,t)
+    (LPCFUNCTION)rp_Bft,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};
+    

--- a/wrappers/Mathcad/includes/rp_betagp.h
+++ b/wrappers/Mathcad/includes/rp_betagp.h
@@ -1,0 +1,54 @@
+LRESULT rp_Bgp(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      p   )
+{
+    char herr[255];
+    int kph = 2;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
+    int ierr;
+    double psat,tsat,rhol,rhov,xliq[20],xvap[20];
+    double xkappa, beta = 0.0, xisenk, xkt, betas, bs, xkkt, thrott, pi, spht;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( p->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        psat = p->real * 1000.0;
+
+    SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141))
+            return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    THERM3dll(&tsat, &rhov, &x[0], &xkappa,
+        &beta,                                // Volume expansion coefficient (= 1/rho dD/dT) [1/K]
+        &xisenk, &xkt, &betas, &bs, &xkkt,
+        &thrott, &pi, &spht);
+
+    ret->real = beta;       // Return thermal expansion coefficient [1/K]
+
+    return 0;               // return 0 to indicate there was no error
+            
+}
+
+FUNCTIONINFO    rp_betagp = 
+{ 
+    (char *)("rp_betagp"),              // Name by which mathcad will recognize the function
+    (char *)("fluid,p"),                // rp_betagp will be called as rp_betagp(fluid,p)
+    (char *)("Returns the saturation vapor volume expansion coefficient [1/K] given the pressure [MPa]"),
+                                        // description of rp_betagp(fluid,p)
+    (LPCFUNCTION)rp_Bgp,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};
+    

--- a/wrappers/Mathcad/includes/rp_betagt.h
+++ b/wrappers/Mathcad/includes/rp_betagt.h
@@ -1,0 +1,53 @@
+LRESULT rp_Bgt(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      t   )
+{
+    char herr[255];
+    int kph = 2;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
+    int ierr;
+    double psat,tsat,rhol,rhov,xliq[20],xvap[20];
+    double xkappa, beta = 0.0, xisenk, xkt, betas, bs, xkkt, thrott, pi, spht;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( t->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tsat = t->real;
+
+    SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
+            return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    THERM3dll(&tsat, &rhov, &x[0], &xkappa,
+        &beta,                                // Volume expansion coefficient (= 1/rho dD/dT) [1/K]
+        &xisenk, &xkt, &betas, &bs, &xkkt,
+        &thrott, &pi, &spht);
+
+    ret->real = beta;       // Return thermal expansion coefficient [1/K]
+
+    return 0;               // return 0 to indicate there was no error
+            
+}
+
+FUNCTIONINFO    rp_betagt = 
+{ 
+    (char *)("rp_betagt"),              // Name by which mathcad will recognize the function
+    (char *)("fluid,t"),                // rp_betagt will be called as rp_betagt(fluid,t)
+    (char *)("Returns the saturation vapor volume expansion coefficient [1/K] given the temperature [K]"),
+                                        // description of rp_betagt(fluid,t)
+    (LPCFUNCTION)rp_Bgt,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes on 1 argument
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};

--- a/wrappers/Mathcad/includes/rp_betatp.h
+++ b/wrappers/Mathcad/includes/rp_betatp.h
@@ -1,12 +1,13 @@
-LRESULT rp_Cptp(
+LRESULT rp_Btp(
     LPCOMPLEXSCALAR     ret,
     LPCMCSTRING       fluid,
     LPCCOMPLEXSCALAR      t,
     LPCCOMPLEXSCALAR      p   )
 {
-    double tval,pval,Dval;
+    double tval, pval, Dval;
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
-    double Dl, Dv, Q, U, H, S, Cv, Cp = 0.0, W;
+    double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
+    double xkappa, beta = 0.0, xisenk, xkt, betas, bs, xkkt, thrott, pi, spht;
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
@@ -29,9 +30,6 @@ LRESULT rp_Cptp(
 
     if (pval > Pmax*(1 + extr)) return MAKELRESULT(P_OUT_OF_RANGE, 3);
 
-    //===============================================================================
-    // Mod 6/2/2022 to get all the way up to Pmax
-    //===============================================================================
     // Get critical pressure
     if (ncomp > 1)
     {
@@ -53,8 +51,8 @@ LRESULT rp_Cptp(
     {
         // Get single-phase density
         TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
-        // Have density, now call CVCP to get Cv and Cp
-        if (ierr <= 0) CVCPdll(&tval, &Dval, &x[0], &Cv, &Cp);   // Calling CVCPdll should be faster than THERMdll
+        // Have density, now call THERM to get Enthalpy
+        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
     }
     else
     {
@@ -63,9 +61,6 @@ LRESULT rp_Cptp(
             &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
             &ierr, herr, errormessagelength);   // error code and string
     }
-    //===============================================================================
-    // End Mod 6/2/2022 to get all the way up to Pmax
-    //===============================================================================
 
     if (ierr > 0) {
         if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13))
@@ -77,20 +72,25 @@ LRESULT rp_Cptp(
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
     }
+    
+    THERM3dll(&tval, &Dval, &x[0], &xkappa, 
+              &beta,                                // Volume expansion coefficient (= 1/rho dD/dT) [1/K]
+              &xisenk, &xkt, &betas, &bs, &xkkt, 
+              &thrott, &pi, &spht);
 
-    ret->real = Cp / wmm;   // Convert from J/mol-K to kJ/kg-K
+    ret->real = beta;   // Return thermal expansion coefficient [1/K]
 
     return 0;               // return 0 to indicate there was no error
             
 }
 
-FUNCTIONINFO    rp_cptp = 
+FUNCTIONINFO    rp_betatp = 
 { 
-    (char *)("rp_cptp"),                 // Name by which Mathcad will recognize the function
-    (char *)("fluid,t,p"),              // rp_cptp will be called as rp_cptp(fluid,t,p)
-    (char *)("Returns the specific heat [kJ/kg-K] given the temperature [K] and pressure [MPa]"),
-                                        // description of rp_cptp(fluid,t,p)
-    (LPCFUNCTION)rp_Cptp,                // pointer to the executable code
+    (char *)("rp_betatp"),              // Name by which Mathcad will recognize the function
+    (char *)("fluid,t,p"),              // rp_betatp will be called as rp_betatp(fluid,t,p)
+    (char *)("Returns the volume expansion coefficient [1/K] given the temperature [K] and pressure [MPa]"),
+                                        // description of rp_betatp(fluid,t,p)
+    (LPCFUNCTION)rp_Btp,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument

--- a/wrappers/Mathcad/includes/rp_cvtp.h
+++ b/wrappers/Mathcad/includes/rp_cvtp.h
@@ -6,7 +6,7 @@ LRESULT rp_Cvtp(
 {
     double tval,pval,Dval;
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
-    double Dl, Dv, Q, U, H, S, Cv = 0.0, Cp, W, Pdum, hjt;
+    double Dl, Dv, Q, U, H, S, Cv = 0.0, Cp, W;
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
@@ -47,9 +47,6 @@ LRESULT rp_Cvtp(
     }
 
     // If above critical pressure (Liquid) use TPRHO instead of TPFLSH
-    // TODO: Not sure what happens if above Tcrit.  Is this vapor or liquid?  Which flag to set?
-    //       May need to adjust initial guess depending on location.
-    //       Extend this logic to all other functions of TP once it is working.
     if (tval > tc) kph = 2;
     if (pval > pc) kph = 1;
     if ((pval > pc) || (tval > tc))
@@ -57,7 +54,7 @@ LRESULT rp_Cvtp(
         // Get single-phase density
         TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
         // Have density, now call THERM to get Enthalpy
-        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
+        if (ierr <=0) CVCPdll(&tval, &Dval, &x[0], &Cv, &Cp);   // Calling CVCPdll should be faster than THERMdll
     }
     else
     {

--- a/wrappers/Mathcad/includes/rp_gammafp.h
+++ b/wrappers/Mathcad/includes/rp_gammafp.h
@@ -1,0 +1,51 @@
+LRESULT rp_Gfp(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      p   )
+{
+    char herr[255];
+    int kph = 1;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
+    int ierr;
+    double psat, tsat, rhol, rhov, xliq[20], xvap[20];
+    double Cv = 0.0, Cp = 0.0;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( p->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        psat = p->real * 1000.0;
+
+    SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
+            return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    CVCPdll(&tsat, &rhol, &x[0], &Cv, &Cp);
+
+    ret->real = Cp / Cv;    // return gamma [dimensionless]
+
+    return 0;               // return 0 to indicate there was no error
+            
+}  
+
+FUNCTIONINFO    rp_gammafp = 
+{ 
+    (char *)("rp_gammafp"),             // Name by which mathcad will recognize the function
+    (char *)("fluid,p"),                // rp_gammafp will be called as rp_gammafp(fluid,p)
+    (char *)("Returns the saturation liquid heat capacity ratio, Gamma [-] given the pressure [MPa]"),
+                                        // description of rp_gammafp(fluid,p)
+    (LPCFUNCTION)rp_Gfp,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};
+    

--- a/wrappers/Mathcad/includes/rp_gammaft.h
+++ b/wrappers/Mathcad/includes/rp_gammaft.h
@@ -1,0 +1,50 @@
+LRESULT rp_Gft(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      t   )
+{
+    char herr[255];
+    int kph = 1;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)  
+    int ierr;
+    double psat, tsat, rhol, rhov, xliq[20], xvap[20];
+    double Cv = 0.0, Cp = 0.0;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( t->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tsat = t->real;
+
+    SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
+            return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    CVCPdll(&tsat, &rhol, &x[0], &Cv, &Cp);
+
+    ret->real = Cp / Cv;    // return gamma [dimensionless]
+
+    return 0;               // return 0 to indicate there was no error
+            
+}    
+
+FUNCTIONINFO    rp_gammaft = 
+{ 
+    (char *)("rp_gammaft"),             // Name by which mathcad will recognize the function
+    (char *)("fluid,t"),                // rp_gammaft will be called as rp_gammaft(fluid,t)
+    (char *)("Returns the saturation liquid heat capacity ratio, Gamma [-] given the temperature [K]"),
+                                        // description of rp_gammaft(fluid,t)
+    (LPCFUNCTION)rp_Gft,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};

--- a/wrappers/Mathcad/includes/rp_gammagp.h
+++ b/wrappers/Mathcad/includes/rp_gammagp.h
@@ -1,0 +1,51 @@
+LRESULT rp_Ggp(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      p   )
+{
+    char herr[255];
+    int kph = 2;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
+    int ierr;
+    double psat, tsat, rhol, rhov, xliq[20], xvap[20];
+    double Cv = 0.0, Cp = 0.0;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( p->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        psat = p->real * 1000.0;
+
+    SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141))
+            return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    CVCPdll(&tsat, &rhov, &x[0], &Cv, &Cp);
+
+    ret->real = Cp / Cv;    // return gamma [dimensionless]
+
+    return 0;               // return 0 to indicate there was no error
+            
+}
+
+FUNCTIONINFO    rp_gammagp = 
+{ 
+    (char *)("rp_gammagp"),             // Name by which mathcad will recognize the function
+    (char *)("fluid,p"),                // rp_gammagp will be called as rp_gammagp(fluid,p)
+    (char *)("Returns the saturation vapor heat capacity ratio, Gamma [-] given the pressure [MPa]"),
+                                        // description of rp_gammagp(fluid,p)
+    (LPCFUNCTION)rp_Ggp,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};
+    

--- a/wrappers/Mathcad/includes/rp_gammagt.h
+++ b/wrappers/Mathcad/includes/rp_gammagt.h
@@ -1,0 +1,50 @@
+LRESULT rp_Ggt(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      t   )
+{
+    char herr[255];
+    int kph = 2;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
+    int ierr;
+    double psat, tsat, rhol, rhov, xliq[20], xvap[20];
+    double Cv = 0.0, Cp = 0.0;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( t->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tsat = t->real;
+
+    SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
+            return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    CVCPdll(&tsat, &rhov, &x[0], &Cv, &Cp);
+
+    ret->real = Cp / Cv;    // return gamma [dimensionless]
+
+    return 0;               // return 0 to indicate there was no error
+            
+}
+
+FUNCTIONINFO    rp_gammagt = 
+{ 
+    (char *)("rp_gammagt"),             // Name by which mathcad will recognize the function
+    (char *)("fluid,t"),                // rp_gammagt will be called as rp_gammagt(fluid,t)
+    (char *)("Returns the saturation vapor heat capacity ratio, Gamma [-] given the temperature [K]"),
+                                        // description of rp_gammagt(fluid,t)
+    (LPCFUNCTION)rp_Ggt,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};

--- a/wrappers/Mathcad/includes/rp_getRPnum.h
+++ b/wrappers/Mathcad/includes/rp_getRPnum.h
@@ -1,0 +1,25 @@
+LRESULT rp_GetMajor(
+    LPCOMPLEXSCALAR   ret,     // Return REFPROP version number as a real
+    LPCCOMPLEXSCALAR  idum  )  // pointer to the dummy parameter received from Mathcad
+{
+    // NOTE: we don't care what gets passed in, but this clears the unused variable warning.
+    if (idum->imag != 0.0)
+        return MAKELRESULT(MUST_BE_REAL, 2);
+    // Return value should already be stored when REFPROP DLL is loaded...
+    ret->real = vMajor + vMinor/10.0;                                            // assign the major.minor to the output parameter
+    return 0;                                                                    // normal return
+}
+
+FUNCTIONINFO    rp_getRPnum = 
+{                                       // These first three strings are not actually used!!!
+    (char *)("rp_getRPnum"),            // Name by which Mathcad will recognize the function
+    (char *)("idum"),                   // rp_getRPnum will be called as rp_getRPnum(idum); has to have a parameter.
+    (char *)("Returns the NIST Refprop version as a number."),  // description of rp_getRPnum(idum)
+    (LPCFUNCTION)rp_GetMajor,           // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    1,                                  // the function takes one (1) argument
+    { COMPLEX_SCALAR }                  // argument is a scalar
+};
+    
+    
+    

--- a/wrappers/Mathcad/includes/rp_kfp.h
+++ b/wrappers/Mathcad/includes/rp_kfp.h
@@ -32,23 +32,52 @@ LRESULT rp_Kfp(
 
     TRNPRPdll(&tsat, &rhol, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
-    // check for errors and return MAKELRESULT(n,1)
-    if (ierr > 0)
+    // check for errors and handle by returning MAKELRESULT(n,p)
+    // Error codes for TRNPRPdll changed radically in REFPROP 10
+    if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
-        if ((ierr == 39) || (ierr == 40) || (ierr == 50))
-            return MAKELRESULT(NO_TRANSPORT, 1);     // conductivity model not defined
-        else if (ierr == 51)
-            return MAKELRESULT(INFINITE_K, 3);
-        else
-            return MAKELRESULT(UNCONVERGED, 2);
+        // REFPROP 9.1.1 Error Flags
+        if (ierr > 0)
+        {
+            if ((ierr == 39) || (ierr == 40) || (ierr == 50))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if (ierr == 51)
+                return MAKELRESULT(INFINITE_K, 3);
+            else
+                return MAKELRESULT(UNCONVERGED, 2);
+        }
+        else if (ierr < 0) {
+            if ((ierr == -31) || (ierr == -33) || (ierr == -51) || (ierr == -53))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if ((ierr == -32) || (ierr == -52))
+                return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
+            else if (ierr <= -58)
+                return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+        }
+        // else (ierr == 0) >> No error
     }
-    else if (ierr < 0) {
-        if ((ierr == -31) || (ierr == -33) || (ierr == -51) || (ierr == -53))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
-        else if ((ierr == -32) || (ierr == -52))
-            return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
-        else if (ierr <= -58)
-            return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+    else // REFPROP 10 or greater
+    {
+        // REFPROP 10 error flags here
+        if (ierr > 0)
+        {
+            if ((ierr == 502) || (ierr == 540) || (ierr == 541) || (ierr == 542) || (ierr == 543))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // conductivity model not defined
+            else if ((ierr == 73) || (ierr == 74))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if (ierr == 561)
+                return MAKELRESULT(UNCONVERGED, 2);     // Erroneous value returned for ETA or TCX
+            else
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // One or more inputs to ETA or TCX out of bounds
+        }
+        else if (ierr < 0)
+        {
+            if (ierr == -560)
+                return MAKELRESULT(INFINITE_K, 3);
+            else
+                return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
+        }
+        // else (ierr == 0) >> No error
     }
     if (cond < 0)
         return MAKELRESULT(UNCONVERGED, 2);

--- a/wrappers/Mathcad/includes/rp_kft.h
+++ b/wrappers/Mathcad/includes/rp_kft.h
@@ -32,23 +32,52 @@ LRESULT rp_Kft(
 
     TRNPRPdll(&tsat, &rhol, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
-    // check for errors and return MAKELRESULT(n,1)
-    if (ierr > 0)
+    // check for errors and handle by returning MAKELRESULT(n,p)
+    // Error codes for TRNPRPdll changed radically in REFPROP 10
+    if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
-        if ((ierr == 39) || (ierr == 40) || (ierr == 50))
-            return MAKELRESULT(NO_TRANSPORT, 1);     // conductivity model not defined
-        else if (ierr == 51)
-            return MAKELRESULT(INFINITE_K, 3);
-        else
-            return MAKELRESULT(UNCONVERGED, 2);
+        // REFPROP 9.1.1 Error Flags
+        if (ierr > 0)
+        {
+            if ((ierr == 39) || (ierr == 40) || (ierr == 50))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if (ierr == 51)
+                return MAKELRESULT(INFINITE_K, 3);
+            else
+                return MAKELRESULT(UNCONVERGED, 2);
+        }
+        else if (ierr < 0) {
+            if ((ierr == -31) || (ierr == -33) || (ierr == -51) || (ierr == -53))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if ((ierr == -32) || (ierr == -52))
+                return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
+            else if (ierr <= -58)
+                return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+        }
+        // else (ierr == 0) >> No error
     }
-    else if (ierr < 0) {
-        if ((ierr == -31) || (ierr == -33) || (ierr == -51) || (ierr == -53))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
-        else if ((ierr == -32) || (ierr == -52))
-            return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
-        else if (ierr <= -58)
-            return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+    else // REFPROP 10 or greater
+    {
+        // REFPROP 10 error flags here
+        if (ierr > 0)
+        {
+            if ((ierr == 502) || (ierr == 540) || (ierr == 541) || (ierr == 542) || (ierr == 543))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // conductivity model not defined
+            else if ((ierr == 73) || (ierr == 74))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if (ierr == 561)
+                return MAKELRESULT(UNCONVERGED, 2);     // Erroneous value returned for ETA or TCX
+            else
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // One or more inputs to ETA or TCX out of bounds
+        }
+        else if (ierr < 0)
+        {
+            if (ierr == -560)
+                return MAKELRESULT(INFINITE_K, 3);
+            else
+                return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
+        }
+        // else (ierr == 0) >> No error
     }
     if (cond < 0)
         return MAKELRESULT(UNCONVERGED, 2);

--- a/wrappers/Mathcad/includes/rp_kgp.h
+++ b/wrappers/Mathcad/includes/rp_kgp.h
@@ -32,23 +32,52 @@ LRESULT rp_Kgp(
 
     TRNPRPdll(&tsat, &rhov, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
-    // check for errors and return MAKELRESULT(n,1)
-    if (ierr > 0)
+    // check for errors and handle by returning MAKELRESULT(n,p)
+    // Error codes for TRNPRPdll changed radically in REFPROP 10
+    if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
-        if ((ierr == 39) || (ierr == 40) || (ierr == 50))
-            return MAKELRESULT(NO_TRANSPORT, 1);     // conductivity model not defined
-        else if (ierr == 51)
-            return MAKELRESULT(INFINITE_K, 3);
-        else
-            return MAKELRESULT(UNCONVERGED, 2);
+        // REFPROP 9.1.1 Error Flags
+        if (ierr > 0)
+        {
+            if ((ierr == 39) || (ierr == 40) || (ierr == 50))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if (ierr == 51)
+                return MAKELRESULT(INFINITE_K, 3);
+            else
+                return MAKELRESULT(UNCONVERGED, 2);
+        }
+        else if (ierr < 0) {
+            if ((ierr == -31) || (ierr == -33) || (ierr == -51) || (ierr == -53))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if ((ierr == -32) || (ierr == -52))
+                return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
+            else if (ierr <= -58)
+                return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+        }
+        // else (ierr == 0) >> No error
     }
-    else if (ierr < 0) {
-        if ((ierr == -31) || (ierr == -33) || (ierr == -51) || (ierr == -53))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
-        else if ((ierr == -32) || (ierr == -52))
-            return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
-        else if (ierr <= -58)
-            return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+    else // REFPROP 10 or greater
+    {
+        // REFPROP 10 error flags here
+        if (ierr > 0)
+        {
+            if ((ierr == 502) || (ierr == 540) || (ierr == 541) || (ierr == 542) || (ierr == 543))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // conductivity model not defined
+            else if ((ierr == 73) || (ierr == 74))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if (ierr == 561)
+                return MAKELRESULT(UNCONVERGED, 2);     // Erroneous value returned for ETA or TCX
+            else
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // One or more inputs to ETA or TCX out of bounds
+        }
+        else if (ierr < 0)
+        {
+            if (ierr == -560)
+                return MAKELRESULT(INFINITE_K, 3);
+            else
+                return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
+        }
+        // else (ierr == 0) >> No error
     }
     if (cond < 0)
         return MAKELRESULT(UNCONVERGED, 2);

--- a/wrappers/Mathcad/includes/rp_kgt.h
+++ b/wrappers/Mathcad/includes/rp_kgt.h
@@ -32,23 +32,52 @@ LRESULT rp_Kgt(
 
     TRNPRPdll(&tsat, &rhov, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
-    // check for errors and return MAKELRESULT(n,1)
-    if (ierr > 0)
+    // check for errors and handle by returning MAKELRESULT(n,p)
+    // Error codes for TRNPRPdll changed radically in REFPROP 10
+    if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
-        if ((ierr == 39) || (ierr == 40) || (ierr == 50))
-            return MAKELRESULT(NO_TRANSPORT, 1);     // conductivity model not defined
-        else if (ierr == 51)
-            return MAKELRESULT(INFINITE_K, 3);
-        else
-            return MAKELRESULT(UNCONVERGED, 2);
+        // REFPROP 9.1.1 Error Flags
+        if (ierr > 0)
+        {
+            if ((ierr == 39) || (ierr == 40) || (ierr == 50))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if (ierr == 51)
+                return MAKELRESULT(INFINITE_K, 3);
+            else
+                return MAKELRESULT(UNCONVERGED, 2);
+        }
+        else if (ierr < 0) {
+            if ((ierr == -31) || (ierr == -33) || (ierr == -51) || (ierr == -53))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if ((ierr == -32) || (ierr == -52))
+                return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
+            else if (ierr <= -58)
+                return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+        }
+        // else (ierr == 0) >> No error
     }
-    else if (ierr < 0) {
-        if ((ierr == -31) || (ierr == -33) || (ierr == -51) || (ierr == -53))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
-        else if ((ierr == -32) || (ierr == -52))
-            return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
-        else if (ierr <= -58)
-            return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+    else // REFPROP 10 or greater
+    {
+        // REFPROP 10 error flags here
+        if (ierr > 0)
+        {
+            if ((ierr == 502) || (ierr == 540) || (ierr == 541) || (ierr == 542) || (ierr == 543))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // conductivity model not defined
+            else if ((ierr == 73) || (ierr == 74))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if (ierr == 561)
+                return MAKELRESULT(UNCONVERGED, 2);     // Erroneous value returned for ETA or TCX
+            else
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // One or more inputs to ETA or TCX out of bounds
+        }
+        else if (ierr < 0)
+        {
+            if (ierr == -560)
+                return MAKELRESULT(INFINITE_K, 3);
+            else
+                return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
+        }
+        // else (ierr == 0) >> No error
     }
     if (cond < 0)
         return MAKELRESULT(UNCONVERGED, 2);

--- a/wrappers/Mathcad/includes/rp_mufp.h
+++ b/wrappers/Mathcad/includes/rp_mufp.h
@@ -32,21 +32,42 @@ LRESULT rp_Mufp(
 
     TRNPRPdll(&tsat, &rhol, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
-    // check for errors and return MAKELRESULT(n,p)
-    if ((ierr > 0) && (ierr != 51))
+    // check for errors and handle by returning MAKELRESULT(n,p)
+    // Error codes for TRNPRPdll changed radically in REFPROP 10
+    if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
-        if ((ierr == 40) || (ierr == 49) || (ierr == 50))
-            return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
-        else
-            return MAKELRESULT(UNCONVERGED, 2);
+        // REFPROP 9.1.1 Error Flags
+        if ((ierr > 0) && (ierr != 51))
+        {
+            if ((ierr == 40) || (ierr == 49) || (ierr == 50))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else
+                return MAKELRESULT(UNCONVERGED, 2);
+        }
+        else if (ierr < 0) {
+            if ((ierr == -41) || (ierr == -43) || (ierr == -51) || (ierr == -53))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if ((ierr == -42) || (ierr == -52))
+                return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
+            else if (ierr <= -58)
+                return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+        }
     }
-    else if (ierr < 0) {
-        if ((ierr == -41) || (ierr == -43) || (ierr == -51) || (ierr == -53))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
-        else if ((ierr == -42) || (ierr == -52))
-            return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
-        else if (ierr <= -58)
-            return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+    else // Assume REFPROP 10 or greater
+    {
+        // REFPROP 10 error flags here
+        if (ierr > 0)
+        {
+            if ((ierr == 502) || (ierr == 540) || (ierr == 541) || (ierr == 542) || (ierr == 543))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if ((ierr == 73) || (ierr == 74))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if (ierr == 561)
+                return MAKELRESULT(UNCONVERGED, 2);     // Erroneous value returned for ETA or TCX
+            else
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // One or more inputs to ETA or TCX out of bounds
+        }
+        else if (ierr < 0) return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
     }
     if (mu < 0)
         return MAKELRESULT(UNCONVERGED, 2);

--- a/wrappers/Mathcad/includes/rp_mugp.h
+++ b/wrappers/Mathcad/includes/rp_mugp.h
@@ -32,21 +32,42 @@ LRESULT rp_Mugp(
 
     TRNPRPdll(&tsat, &rhov, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
-    // check for errors and return MAKELRESULT(n,p)
-    if ((ierr > 0) && (ierr != 51))
+    // check for errors and handle by returning MAKELRESULT(n,p)
+    // Error codes for TRNPRPdll changed radically in REFPROP 10
+    if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
-        if ((ierr == 40) || (ierr == 49) || (ierr == 50))
-            return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
-        else
-            return MAKELRESULT(UNCONVERGED, 2);
+        // REFPROP 9.1.1 Error Flags
+        if ((ierr > 0) && (ierr != 51))
+        {
+            if ((ierr == 40) || (ierr == 49) || (ierr == 50))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else
+                return MAKELRESULT(UNCONVERGED, 2);
+        }
+        else if (ierr < 0) {
+            if ((ierr == -41) || (ierr == -43) || (ierr == -51) || (ierr == -53))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if ((ierr == -42) || (ierr == -52))
+                return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
+            else if (ierr <= -58)
+                return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+        }
     }
-    else if (ierr < 0) {
-        if ((ierr == -41) || (ierr == -43) || (ierr == -51) || (ierr == -53))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
-        else if ((ierr == -42) || (ierr == -52))
-            return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
-        else if (ierr <= -58)
-            return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+    else // Assume REFPROP 10 or greater
+    {
+        // REFPROP 10 error flags here
+        if (ierr > 0)
+        {
+            if ((ierr == 502) || (ierr == 540) || (ierr == 541) || (ierr == 542) || (ierr == 543))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if ((ierr == 73) || (ierr == 74))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if (ierr == 561)
+                return MAKELRESULT(UNCONVERGED, 2);     // Erroneous value returned for ETA or TCX
+            else
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // One or more inputs to ETA or TCX out of bounds
+        }
+        else if (ierr < 0) return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
     }
     if (mu < 0)
         return MAKELRESULT(UNCONVERGED, 2);

--- a/wrappers/Mathcad/includes/rp_mugt.h
+++ b/wrappers/Mathcad/includes/rp_mugt.h
@@ -32,21 +32,42 @@ LRESULT rp_Mugt(
 
     TRNPRPdll(&tsat,&rhov,&x[0],&mu,&cond,&ierr,herr, errormessagelength);
 
-    // check for errors and return MAKELRESULT(n,p)
-    if ((ierr > 0) && (ierr != 51))
+    // check for errors and handle by returning MAKELRESULT(n,p)
+    // Error codes for TRNPRPdll changed radically in REFPROP 10
+    if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
-        if ((ierr == 40) || (ierr == 49) || (ierr == 50))
-            return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
-        else
-            return MAKELRESULT(UNCONVERGED, 2);
+        // REFPROP 9.1.1 Error Flags
+        if ((ierr > 0) && (ierr != 51))
+        {
+            if ((ierr == 40) || (ierr == 49) || (ierr == 50))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else
+                return MAKELRESULT(UNCONVERGED, 2);
+        }
+        else if (ierr < 0) {
+            if ((ierr == -41) || (ierr == -43) || (ierr == -51) || (ierr == -53))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if ((ierr == -42) || (ierr == -52))
+                return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
+            else if (ierr <= -58)
+                return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+        }
     }
-    else if (ierr < 0) {
-        if ((ierr == -41) || (ierr == -43) || (ierr == -51) || (ierr == -53))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
-        else if ((ierr == -42) || (ierr == -52))
-            return MAKELRESULT(D_OUT_OF_RANGE, 3);  // Pressure (density) out of bounds
-        else if (ierr <= -58)
-            return MAKELRESULT(UNCONVERGED, 2);     // did not converge
+    else // Assume REFPROP 10 or greater
+    {
+        // REFPROP 10 error flags here
+        if (ierr > 0)
+        {
+            if ((ierr == 502) || (ierr == 540) || (ierr == 541) || (ierr == 542) || (ierr == 543))
+                return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if ((ierr == 73) || (ierr == 74))
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+            else if (ierr == 561)
+                return MAKELRESULT(UNCONVERGED, 2);     // Erroneous value returned for ETA or TCX
+            else
+                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // One or more inputs to ETA or TCX out of bounds
+        }
+        else if (ierr < 0) return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
     }
     if (mu < 0)
         return MAKELRESULT(UNCONVERGED, 2);

--- a/wrappers/Mathcad/includes/rp_pcrit.h
+++ b/wrappers/Mathcad/includes/rp_pcrit.h
@@ -1,5 +1,3 @@
-    
-    
 LRESULT rp_Pcrit(
     LPCOMPLEXSCALAR      ret,
     LPCMCSTRING        fluid,
@@ -27,9 +25,16 @@ LRESULT rp_Pcrit(
     {
         CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, lherr);
         if (ierr > 0)
-        {
-            return MAKELRESULT(UNKNOWN, 2);
-        }        
+        {      // REFPROP 9 ||-> REFPROP 10+
+            if ((ierr == 1) || (ierr == 314) || (ierr == 315) || (ierr == 317))
+                return MAKELRESULT(UNCONVERGED, 1);
+            else if ((ierr == 312) || (ierr == 805))
+                return MAKELRESULT(X_SUM_NONUNITY, 1);
+            else
+                return MAKELRESULT(UNKNOWN, 2);
+        }
+        else if ((ierr == -131) || (ierr == -132))    // REFPROP 9 codes
+            return MAKELRESULT(UNKNOWN, 1);
     }
     else
     {
@@ -45,9 +50,9 @@ LRESULT rp_Pcrit(
 
 FUNCTIONINFO    rp_pcrit = 
 { 
-    (char *)("rp_pcrit"),                          // Name by which mathcad will recognize the function
-    (char *)("fluid,comp"),                        // rp_pcrit will be called as rp_pcrit(fluid,comp)
-    (char *)("Returns critical pressure [MPa] of the component number specified"),
+    (char *)("rp_pcrit"),               // Name by which mathcad will recognize the function
+    (char *)("fluid,comp"),             // rp_pcrit will be called as rp_pcrit(fluid,comp)
+    (char *)("Returns critical pressure [MPa] of the mixture or component number specified"),
                                         // description of rp_pcrit(fluid,comp)
     (LPCFUNCTION)rp_Pcrit,              // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar

--- a/wrappers/Mathcad/includes/rp_prfp.h
+++ b/wrappers/Mathcad/includes/rp_prfp.h
@@ -1,34 +1,34 @@
-LRESULT rp_Muft(
+LRESULT rp_PRfp(
     LPCOMPLEXSCALAR     ret,
     LPCMCSTRING       fluid,
-    LPCCOMPLEXSCALAR      t)
+    LPCCOMPLEXSCALAR      p   )
 {
     char herr[255];
-    int kph = 1;   // looking for saturated liquid (bubble point)
+    int kph = 1;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
     int ierr;
     double psat, tsat, rhol, rhov, xliq[20], xvap[20];
-    double mu, cond;
+    double Cv, Cp, mu, cond;
 
     ierr = cSetup(fluid->str);
     if (ierr > 0)
-        return MAKELRESULT(ierr, 1);
-
-    if (t->imag != 0.0)
-        return MAKELRESULT(MUST_BE_REAL, 2);
+        return MAKELRESULT(ierr,1);
+    
+    if( p->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
     else
-        tsat = t->real;            // T in [K]
+        psat = p->real * 1000.0;
 
-    SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
+    SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
     if (ierr > 0)
     {
-        if ((ierr == 1) || (ierr == 9) || (ierr == 121))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit
-        else if (ierr == 8)
-            return MAKELRESULT(BAD_COMPONENT, 1); // x out of range
+        if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141) || (ierr == 145))
+            return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
         else
-            return MAKELRESULT(UNCONVERGED, 2); // failed to converge
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
     }
+
+    CVCPdll(&tsat, &rhol, &x[0], &Cv, &Cp);
 
     TRNPRPdll(&tsat, &rhol, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
@@ -37,10 +37,12 @@ LRESULT rp_Muft(
     if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
         // REFPROP 9.1.1 Error Flags
-        if ((ierr > 0) && (ierr != 51))
+        if (ierr > 0)
         {
             if ((ierr == 40) || (ierr == 49) || (ierr == 50))
                 return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if (ierr == 51)
+                return MAKELRESULT(INFINITE_K, 3);
             else
                 return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -69,24 +71,31 @@ LRESULT rp_Muft(
         }
         else if (ierr < 0) return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
     }
-    if (mu < 0)
+    if ((mu < 0) || (cond < 0))
         return MAKELRESULT(UNCONVERGED, 2);
 
-    ret->real = mu;       // returned in µPa-s
+    // µ returned in [µPa-s] = [mg / m-s]
+    // k returned in [W/m-K] = [J/m-s-K]
+    // Cp returned in [J/mol-K]
+    // wmm returned in [g/mol]
+    ret->real = mu * Cp / wmm / cond / 1000;   // Conversion: (µPa-s) * (J/mol-K) / (g/mol) / (W/m*K) / (mg/g) = 
+                                               //          (mg/m-s) * (J/mol-K) * (mol/g) * (m-s-K/J) * (g/mg) =
+                                               //          [dimensionless]
 
     return 0;               // return 0 to indicate there was no error
+            
+}  
 
-}
-
-FUNCTIONINFO    rp_muft =
-{
-    (char *)("rp_muft"),                // Name by which mathcad will recognize the function
-    (char *)("fluid,t"),                // rp_muft will be called as rp_muft(fluid,t)
-    (char *)("Returns the saturation liquid viscosity [µPa-s] given the saturation temperature [K]"),
-                                        // description of rp_muft(fluid,t)
-    (LPCFUNCTION)rp_Muft,               // pointer to the executable code
+FUNCTIONINFO    rp_prfp = 
+{ 
+    (char *)("rp_prfp"),                // Name by which mathcad will recognize the function
+    (char *)("fluid,p"),                // rp_prfp will be called as rp_prfp(fluid,p)
+    (char *)("Returns the saturation liquid Prandtl Number [-] given the pressure [MPa]"),
+                                        // description of rp_prfp(fluid,p)
+    (LPCFUNCTION)rp_PRfp,               // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes 2 arguments
-    { MC_STRING,                        // String argument
-    COMPLEX_SCALAR }                    // argument is a complex scalar
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };
+    

--- a/wrappers/Mathcad/includes/rp_prft.h
+++ b/wrappers/Mathcad/includes/rp_prft.h
@@ -1,34 +1,34 @@
-LRESULT rp_Muft(
+LRESULT rp_PRft(
     LPCOMPLEXSCALAR     ret,
     LPCMCSTRING       fluid,
-    LPCCOMPLEXSCALAR      t)
+    LPCCOMPLEXSCALAR      t   )
 {
     char herr[255];
-    int kph = 1;   // looking for saturated liquid (bubble point)
+    int kph = 1;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)  
     int ierr;
     double psat, tsat, rhol, rhov, xliq[20], xvap[20];
-    double mu, cond;
+    double Cv, Cp, mu, cond;
 
     ierr = cSetup(fluid->str);
     if (ierr > 0)
-        return MAKELRESULT(ierr, 1);
-
-    if (t->imag != 0.0)
-        return MAKELRESULT(MUST_BE_REAL, 2);
+        return MAKELRESULT(ierr,1);
+    
+    if( t->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
     else
-        tsat = t->real;            // T in [K]
+        tsat = t->real;
 
     SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
     if (ierr > 0)
     {
-        if ((ierr == 1) || (ierr == 9) || (ierr == 121))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit
-        else if (ierr == 8)
-            return MAKELRESULT(BAD_COMPONENT, 1); // x out of range
+        if ((ierr == 1) || (ierr == 9) || (ierr == 121) || (ierr == 125))
+            return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit or Tmax (cricondentherm)
         else
-            return MAKELRESULT(UNCONVERGED, 2); // failed to converge
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
     }
+
+    CVCPdll(&tsat, &rhol, &x[0], &Cv, &Cp);
 
     TRNPRPdll(&tsat, &rhol, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
@@ -37,10 +37,12 @@ LRESULT rp_Muft(
     if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
         // REFPROP 9.1.1 Error Flags
-        if ((ierr > 0) && (ierr != 51))
+        if (ierr > 0)
         {
             if ((ierr == 40) || (ierr == 49) || (ierr == 50))
                 return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if (ierr == 51)
+                return MAKELRESULT(INFINITE_K, 3);
             else
                 return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -69,24 +71,31 @@ LRESULT rp_Muft(
         }
         else if (ierr < 0) return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
     }
-    if (mu < 0)
+    if ((mu < 0) || (cond < 0))
         return MAKELRESULT(UNCONVERGED, 2);
 
-    ret->real = mu;       // returned in µPa-s
+    // µ returned in [µPa-s] = [mg / m-s]
+    // k returned in [W/m-K] = [J/m-s-K]
+    // Cp returned in [J/mol-K]
+    // wmm returned in [g/mol]
+    ret->real = mu * Cp / wmm / cond / 1000;   // Conversion: (µPa-s) * (J/mol-K) / (g/mol) / (W/m*K) / (mg/g) = 
+                                               //          (mg/m-s) * (J/mol-K) * (mol/g) * (m-s-K/J) * (g/mg) =
+                                               //          [dimensionless]
 
     return 0;               // return 0 to indicate there was no error
+            
+}    
 
-}
-
-FUNCTIONINFO    rp_muft =
-{
-    (char *)("rp_muft"),                // Name by which mathcad will recognize the function
-    (char *)("fluid,t"),                // rp_muft will be called as rp_muft(fluid,t)
-    (char *)("Returns the saturation liquid viscosity [µPa-s] given the saturation temperature [K]"),
-                                        // description of rp_muft(fluid,t)
-    (LPCFUNCTION)rp_Muft,               // pointer to the executable code
+FUNCTIONINFO    rp_prft = 
+{ 
+    (char *)("rp_prft"),                // Name by which mathcad will recognize the function
+    (char *)("fluid,t"),                // rp_prft will be called as rp_prft(fluid,t)
+    (char *)("Returns the saturation liquid Prandtl Number [-] given the temperature [K]"),
+                                        // description of rp_prft(fluid,t)
+    (LPCFUNCTION)rp_PRft,               // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes 2 arguments
-    { MC_STRING,                        // String argument
-    COMPLEX_SCALAR }                    // argument is a complex scalar
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };
+    

--- a/wrappers/Mathcad/includes/rp_prgp.h
+++ b/wrappers/Mathcad/includes/rp_prgp.h
@@ -1,46 +1,48 @@
-LRESULT rp_Muft(
+LRESULT rp_PRgp(
     LPCOMPLEXSCALAR     ret,
     LPCMCSTRING       fluid,
-    LPCCOMPLEXSCALAR      t)
+    LPCCOMPLEXSCALAR      p   )
 {
     char herr[255];
-    int kph = 1;   // looking for saturated liquid (bubble point)
+    int kph = 2;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
     int ierr;
     double psat, tsat, rhol, rhov, xliq[20], xvap[20];
-    double mu, cond;
+    double Cv, Cp, mu, cond;
 
     ierr = cSetup(fluid->str);
     if (ierr > 0)
-        return MAKELRESULT(ierr, 1);
-
-    if (t->imag != 0.0)
-        return MAKELRESULT(MUST_BE_REAL, 2);
+        return MAKELRESULT(ierr,1);
+    
+    if( p->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
     else
-        tsat = t->real;            // T in [K]
+        psat = p->real * 1000.0;
 
-    SATTdll(&tsat, &x[0], &kph, &psat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
+    SATPdll(&psat, &x[0], &kph, &tsat, &rhol, &rhov, &xliq[0], &xvap[0], &ierr, herr, errormessagelength);
 
     if (ierr > 0)
     {
-        if ((ierr == 1) || (ierr == 9) || (ierr == 121))
-            return MAKELRESULT(T_OUT_OF_RANGE, 2); // Temperature too low | negative | > Tcrit
-        else if (ierr == 8)
-            return MAKELRESULT(BAD_COMPONENT, 1); // x out of range
+        if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141) || (ierr == 145))
+            return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low || negative || > Pcrit or Pmaax (cricondenbar)
         else
-            return MAKELRESULT(UNCONVERGED, 2); // failed to converge
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
     }
 
-    TRNPRPdll(&tsat, &rhol, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
+    CVCPdll(&tsat, &rhov, &x[0], &Cv, &Cp);
+
+    TRNPRPdll(&tsat, &rhov, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
     // check for errors and handle by returning MAKELRESULT(n,p)
     // Error codes for TRNPRPdll changed radically in REFPROP 10
     if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
         // REFPROP 9.1.1 Error Flags
-        if ((ierr > 0) && (ierr != 51))
+        if (ierr > 0)
         {
             if ((ierr == 40) || (ierr == 49) || (ierr == 50))
                 return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if (ierr == 51)
+                return MAKELRESULT(INFINITE_K, 3);
             else
                 return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -69,24 +71,31 @@ LRESULT rp_Muft(
         }
         else if (ierr < 0) return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
     }
-    if (mu < 0)
+    if ((mu < 0) || (cond < 0))
         return MAKELRESULT(UNCONVERGED, 2);
 
-    ret->real = mu;       // returned in µPa-s
+    // µ returned in [µPa-s] = [mg / m-s]
+    // k returned in [W/m-K] = [J/m-s-K]
+    // Cp returned in [J/mol-K]
+    // wmm returned in [g/mol]
+    ret->real = mu * Cp / wmm / cond / 1000;   // Conversion: (µPa-s) * (J/mol-K) / (g/mol) / (W/m*K) / (mg/g) = 
+                                               //          (mg/m-s) * (J/mol-K) * (mol/g) * (m-s-K/J) * (g/mg) =
+                                               //          [dimensionless]
 
     return 0;               // return 0 to indicate there was no error
-
+            
 }
 
-FUNCTIONINFO    rp_muft =
-{
-    (char *)("rp_muft"),                // Name by which mathcad will recognize the function
-    (char *)("fluid,t"),                // rp_muft will be called as rp_muft(fluid,t)
-    (char *)("Returns the saturation liquid viscosity [µPa-s] given the saturation temperature [K]"),
-                                        // description of rp_muft(fluid,t)
-    (LPCFUNCTION)rp_Muft,               // pointer to the executable code
+FUNCTIONINFO    rp_prgp = 
+{ 
+    (char *)("rp_prgp"),                // Name by which mathcad will recognize the function
+    (char *)("fluid,p"),                // rp_prgp will be called as rp_prgp(fluid,p)
+    (char *)("Returns the saturated vapor Prandtl Number [-] given the pressure [MPa]"),
+                                        // description of rp_prgp(fluid,p)
+    (LPCFUNCTION)rp_PRgp,               // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes 2 arguments
-    { MC_STRING,                        // String argument
-    COMPLEX_SCALAR }                    // argument is a complex scalar
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
 };
+    

--- a/wrappers/Mathcad/includes/rp_prtp.h
+++ b/wrappers/Mathcad/includes/rp_prtp.h
@@ -1,46 +1,46 @@
-LRESULT rp_Mutp(
+LRESULT rp_PRtp(
     LPCOMPLEXSCALAR     ret,
     LPCMCSTRING       fluid,
     LPCCOMPLEXSCALAR      t,
-    LPCCOMPLEXSCALAR      p)
+    LPCCOMPLEXSCALAR      p   )
 {
-    double mu,cond;
-    double tval, pval, Dval;
+    double tval,pval,Dval;
     double TminV, TmaxV, DmaxV, PmaxV;                          // Viscosity Limits
+    double TminK, TmaxK, DmaxK, PmaxK;                          // TC Limits
     double ttrip, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
-    double Dl, Dv, Q, U, H, S, Cv, Cp, W, Pdum, hjt;
+    double Dl, Dv, Q, U, H, S, Cv, Cp = 0.0, W;
+    double mu, cond;                                            // Viscosity, TC values
     double xl[20], xv[20];
     int ierr = 0, icomp = 1, kph = 1, kguess = 0;
     char herr[255];
-    char htype[] = "ETA";
+    char htypeV[] = "ETA";                                      // Viscosity equation set
+    char htypeK[] = "TCX";                                      // Thermal Conductivity equation set
 
     ierr = cSetup(fluid->str);
     if (ierr > 0)
-        return MAKELRESULT(ierr, 1);
+        return MAKELRESULT(ierr,1);
 
-    if (t->imag != 0.0)
-        return MAKELRESULT(MUST_BE_REAL, 2);
+    if( t->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
     else
         tval = t->real;
 
-    if (p->imag != 0.0)
-        return MAKELRESULT(MUST_BE_REAL, 3);
+    if( p->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,3);
     else
         pval = p->real * 1000.0;   // Convert from MPa to kPa for REFPROP inputs
 
-                                   // Get Limits for TCX model
-    LIMITSdll(htype, &x[0], &TminV, &TmaxV, &DmaxV, &PmaxV, lengthofreference);
+    //======================== Check EOS, Viscosity, and Thermal Conductivity Limits ==================================
+    LIMITSdll(htypeV, &x[0], &TminV, &TmaxV, &DmaxV, &PmaxV, lengthofreference);
+    LIMITSdll(htypeK, &x[0], &TminK, &TmaxK, &DmaxK, &PmaxK, lengthofreference);
 
-    if ((tval > std::min(Tmax, TmaxV)*(1 + 0.5*extr)) ||   // if above Tmax for EOS or ETA, or
-        (tval < std::max(Tmin, TminV)))                    //    below Tmin for EOS or ETA,
-        return MAKELRESULT(T_OUT_OF_RANGE, 2);            //    throw error.
+    if ((tval > std::min(std::min(Tmax, TmaxV), TmaxK)*(1.0 + 0.5*extr)) ||   // if above Tmax for EOS or ETA or TCX, or
+        (tval < std::max(std::max(Tmin, TminV), TminK)))                      //    below Tmin for EOS or ETA or TCX,
+        return MAKELRESULT(T_OUT_OF_RANGE, 2);                                //    throw error.
 
-    if (pval > std::min(Pmax, PmaxV)*(1 + extr))           // if above Pmax for EOS or ETA,
-        return MAKELRESULT(P_OUT_OF_RANGE, 3);            //    throw error.
+    if (pval > std::min(std::min(Pmax, PmaxV), PmaxK)*(1.0 + extr))           // if above Pmax for EOS or ETA or TCX,
+        return MAKELRESULT(P_OUT_OF_RANGE, 3);                                //    throw error.
 
-    //===============================================================================
-    // Mod 6/2/2022 to get all the way up to Pmax
-    //===============================================================================
     // Get critical pressure
     if (ncomp > 1)
     {
@@ -55,10 +55,7 @@ LRESULT rp_Mutp(
         INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
     }
 
-    // If above critical pressure (Liquid) use TPRHO instead of TPFLSH
-    // TODO: Not sure what happens if above Tcrit.  Is this vapor or liquid?  Which flag to set?
-    //       May need to adjust initial guess depending on location.
-    //       Extend this logic to all other functions of TP once it is working.
+    // If above critical pressure (Liquid) and/or critical temperature (Vapor) use TPRHO instead of TPFLSH
     if (tval > tc) kph = 2;
     if (pval > pc) kph = 1;
     if ((pval > pc) || (tval > tc))
@@ -66,7 +63,7 @@ LRESULT rp_Mutp(
         // Get single-phase density
         TPRHOdll(&tval, &pval, &x[0], &kph, &kguess, &Dval, &ierr, herr, errormessagelength);
         // Have density, now call THERM to get Enthalpy
-        if (ierr <=0) THERMdll(&tval, &Dval, &x[0], &Pdum, &U, &H, &S, &Cv, &Cp, &W, &hjt);
+        if (ierr <=0) CVCPdll(&tval, &Dval, &x[0], &Cv, &Cp);   // Calling CVCPdll should be faster than THERMdll
     }
     else
     {
@@ -75,37 +72,31 @@ LRESULT rp_Mutp(
             &Q, &U, &H, &S, &Cv, &Cp, &W,       // Thermo properties
             &ierr, herr, errormessagelength);   // error code and string
     }
-    //===============================================================================
-    // End Mod 6/2/2022 to get all the way up to Pmax
-    //===============================================================================
-
-    if (ierr > 0) {
-        // Use this pop-up window for debugging if needed
-        //===============================================================================
-        //msg = format("\n  ierr: %d",ierr);
-        //MessageBox(hwndDlg, msg.c_str(), "NIST RefProp Add-In", 0);
-        //===============================================================================
-        if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13))
+    // Check for errors
+    if (ierr > 0) {  //                                                     RP10    
+        if ((ierr == 1) || (ierr == 5) || (ierr == 9) || (ierr == 13) || (ierr == 17))
             return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
         else if ((ierr == 4) || (ierr == 12))
-            return MAKELRESULT(P_OUT_OF_RANGE, 3);  // Pressure out of bounds
+            return MAKELRESULT(P_OUT_OF_RANGE, 1);  // Pressure out of bounds
         else if (ierr == 8)
             return MAKELRESULT(X_SUM_NONUNITY, 1);  // component and/or sum < 0 or > 1
         else
             return MAKELRESULT(UNCONVERGED, 2);     // one of many convergence errors
     }
 
-    TRNPRPdll(&tval,&Dval,&x[0],&mu,&cond,&ierr,herr,errormessagelength);
+    TRNPRPdll(&tval, &Dval, &x[0], &mu, &cond, &ierr, herr, errormessagelength);
 
     // check for errors and handle by returning MAKELRESULT(n,p)
     // Error codes for TRNPRPdll changed radically in REFPROP 10
     if (vMajor < 10)  // Can only be REFPROP 9.1.1 or 10+ if we are here
     {
         // REFPROP 9.1.1 Error Flags
-        if ((ierr > 0) && (ierr != 51))
+        if (ierr > 0)
         {
             if ((ierr == 40) || (ierr == 49) || (ierr == 50))
                 return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
+            else if (ierr == 51)
+                return MAKELRESULT(INFINITE_K, 3);
             else
                 return MAKELRESULT(UNCONVERGED, 2);
         }
@@ -126,34 +117,42 @@ LRESULT rp_Mutp(
             if ((ierr == 502) || (ierr == 540) || (ierr == 541) || (ierr == 542) || (ierr == 543))
                 return MAKELRESULT(NO_TRANSPORT, 1);     // viscosity model not defined
             else if ((ierr == 73) || (ierr == 74))
-                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // Temperature out of bounds
+                return MAKELRESULT(UNKNOWN, 2);  // inputs out of bounds
             else if (ierr == 561)
                 return MAKELRESULT(UNCONVERGED, 2);     // Erroneous value returned for ETA or TCX
             else
-                return MAKELRESULT(T_OUT_OF_RANGE, 2);  // One or more inputs to ETA or TCX out of bounds
+                return MAKELRESULT(UNKNOWN, 2);  // One or more inputs to ETA or TCX out of bounds
         }
         else if (ierr < 0) return MAKELRESULT(UNCONVERGED, 2);  // Either ETA or TCX did not converge
     }
-    if (mu < 0)
-        return MAKELRESULT(UNCONVERGED,2);
+    if ((mu < 0) || (cond < 0))
+        return MAKELRESULT(UNCONVERGED, 2);
 
-    ret->real = mu;         // returned in µPa-s
+    // µ returned in [µPa-s] = [mg / m-s]
+    // k returned in [W/m-K] = [J/m-s-K]
+    // Cp returned in [J/mol-K]
+    // wmm returned in [g/mol]
+    ret->real = mu * Cp / wmm / cond / 1000;   // Conversion: (µPa-s) * (J/mol-K) / (g/mol) / (W/m*K) / (mg/g) = 
+                                               //          (mg/m-s) * (J/mol-K) * (mol/g) * (m-s-K/J) * (g/mg) =
+                                               //          [dimensionless]
 
     return 0;               // return 0 to indicate there was no error
             
-}           
+}
 
-FUNCTIONINFO    rp_mutp = 
+FUNCTIONINFO    rp_prtp = 
 { 
-    (char *)("rp_mutp"),                // Name by which mathcad will recognize the function
-    (char *)("fluid,t,p"),              // rp_mutp will be called as rp_mutp(fluid,t,p)
-    (char *)("Returns the viscosity [µPa-s] given the temperature [K] and pressure [MPa]"),
-                                        // description of rp_mutp(fluid,t,p)
-    (LPCFUNCTION)rp_Mutp,               // pointer to the executable code
+    (char *)("rp_prtp"),                 // Name by which Mathcad will recognize the function
+    (char *)("fluid,t,p"),              // rp_prtp will be called as rp_prtp(fluid,t,p)
+    (char *)("Returns the Prandtl Number [-] given the temperature [K] and pressure [MPa]"),
+                                        // description of rp_prtp(fluid,t,p)
+    (LPCFUNCTION)rp_PRtp,                // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     3,                                  // the function takes on 3 arguments
     { MC_STRING,                        // String argument
       COMPLEX_SCALAR,
       COMPLEX_SCALAR }                  // arguments are complex scalars
 };
+    
+    
     

--- a/wrappers/Mathcad/includes/rp_rhocrit.h
+++ b/wrappers/Mathcad/includes/rp_rhocrit.h
@@ -24,9 +24,17 @@ LRESULT rp_Rhocrit(
     {
         CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, lherr);
         if (ierr > 0)
-        {
-            return MAKELRESULT(9,2);
+        {      // REFPROP 9 ||-> REFPROP 10+
+            if ((ierr == 1) || (ierr == 314) || (ierr == 315) || (ierr == 317))
+                return MAKELRESULT(UNCONVERGED, 1);
+            else if ((ierr == 312) || (ierr == 805))
+                return MAKELRESULT(X_SUM_NONUNITY, 1);
+            else
+                return MAKELRESULT(UNKNOWN, 2);
         }
+        else if ((ierr == -131) || (ierr == -132))    // REFPROP 9 codes
+            return MAKELRESULT(UNKNOWN, 1);
+
         wmm0 = wmm;
     }
     else 
@@ -45,7 +53,7 @@ FUNCTIONINFO    rp_rhocrit =
 { 
     (char *)("rp_rhocrit"),             // Name by which Mathcad will recognize the function
     (char *)("fluid,comp"),             // rp_rhocrit will be called as rp_rhocrit(fluid,comp)
-    (char *)("Returns the critical point density [kg/m^3] of the component number specified"),
+    (char *)("Returns the critical point density [kg/m^3] of the mixture or component number specified"),
                                         // description of rp_rhocrit(fluid,comp)
     (LPCFUNCTION)rp_Rhocrit,            // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar

--- a/wrappers/Mathcad/includes/rp_zcrit.h
+++ b/wrappers/Mathcad/includes/rp_zcrit.h
@@ -1,7 +1,7 @@
-LRESULT rp_Tcrit(
-    LPCOMPLEXSCALAR     ret,
-    LPCMCSTRING       fluid,
-    LPCCOMPLEXSCALAR   comp   )
+LRESULT rp_Zcrit(
+    LPCOMPLEXSCALAR      ret,
+    LPCMCSTRING        fluid,
+    LPCCOMPLEXSCALAR    comp   )
 {
     char herr[255];
     unsigned int lherr = 255;
@@ -17,12 +17,13 @@ LRESULT rp_Tcrit(
         return MAKELRESULT(MUST_BE_REAL,2);
     else
         icomp = static_cast<int>(comp->real);
-    
+
     if ((icomp > ncomp)||(icomp < 0))
         return MAKELRESULT(BAD_COMPONENT,2);
-    else if ((icomp == 0)&&(ncomp > 1))
+
+    if ((icomp == 0) && (ncomp > 1))   // mixture
     {
-        CRITPdll(&x[0],&tc,&pc,&Dc,&ierr,herr,lherr);
+        CRITPdll(&x[0], &tc, &pc, &Dc, &ierr, herr, lherr);
         if (ierr > 0)
         {      // REFPROP 9 ||-> REFPROP 10+
             if ((ierr == 1) || (ierr == 314) || (ierr == 315) || (ierr == 317))
@@ -34,26 +35,30 @@ LRESULT rp_Tcrit(
         }
         else if ((ierr == -131) || (ierr == -132))    // REFPROP 9 codes
             return MAKELRESULT(UNKNOWN, 1);
+
+        RMIX2dll(&x[0], &Rgas);              // mixture gas constant [J/mol-K]
+                                             // pc [kPa] >> [J/L]
+                                             // tc [K]
+                                             // Dc [mol/L]
+        ret->real = pc / ( Rgas * tc * Dc);  // [J/L] * [mol-K/J] * [1/K] * [L/mol] >> [-]
     }
-    else 
+    else   // pure component
     {
         if (icomp == 0) icomp = 1;
         INFOdll(&icomp,&wmm,&ttrip,&tnbpt,&tc,&pc,&Dc,&Zc,&acf,&dip,&Rgas);
+        ret->real = Zc;  // Return compressibility factor directly from INFO
     }
-        
-    ret->real = tc;
 
     return 0;               // return 0 to indicate there was no error
-
 }
 
-    FUNCTIONINFO    rp_tcrit = 
+FUNCTIONINFO    rp_zcrit = 
 { 
-    (char *)("rp_tcrit"),               // Name by which Mathcad will recognize the function
-    (char *)("fluid,comp"),             // rp_tcrit will be called as rp_tcrit(fluid,comp)
-    (char *)("Returns critical point temperature [K] of the mixture or component number specified"),
-                                        // description of rp_tcrit(fluid,comp)
-    (LPCFUNCTION)rp_Tcrit,              // pointer to the executable code
+    (char *)("rp_zcrit"),               // Name by which mathcad will recognize the function
+    (char *)("fluid,comp"),             // rp_zcrit will be called as rp_zcrit(fluid,comp)
+    (char *)("Returns critical point compressibility factor [-] of the mixture or component number specified"),
+                                        // description of rp_zcrit(fluid,comp)
+    (LPCFUNCTION)rp_Zcrit,              // pointer to the executable code
     COMPLEX_SCALAR,                     // the return type is a complex scalar
     2,                                  // the function takes on 1 argument
     { MC_STRING,

--- a/wrappers/Mathcad/includes/rp_zfp.h
+++ b/wrappers/Mathcad/includes/rp_zfp.h
@@ -1,0 +1,64 @@
+LRESULT rp_Zfp(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      p   )
+{
+    char herr[255];
+    int kph = 1;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
+    int ierr;
+    int icomp = 1;
+    double psat, tsat, rhol, rhov, xliq[20], xvap[20];
+    double tc, pc, Dc, Rgas, ttrip, tnbpt, Zc, acf, dip;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+
+    if( p->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        psat = p->real * 1000.0;
+
+    SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 2) || (ierr == 4) || (ierr == 12) || (ierr == 141))
+            return MAKELRESULT(P_OUT_OF_RANGE, 2); // Pressure too low | negative | > Pcrit
+        else if (ierr == 8)
+            return MAKELRESULT(X_SUM_NONUNITY, 1);
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    // Update sat liquid temperature if mixture using correct density
+    TSATDdll(&rhol, &x[0], &tsat, &ierr, herr, errormessagelength);
+
+    // Get Rgas
+    if (ncomp > 1)
+    {
+        RMIX2dll(&x[0], &Rgas);              // mixture gas constant [J/mol-K]
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
+
+    ret->real = psat / (Rgas * tsat * rhol);   // calculate compressibility factor
+
+    return 0;               // return 0 to indicate there was no error
+
+}
+
+FUNCTIONINFO    rp_zfp =
+{
+    (char *)("rp_zfp"),                 // Name by which mathcad will recognize the function
+    (char *)("fluid,p"),                // rp_zfp will be called as rp_zfp(fluid,p)
+    (char *)("Returns the saturation liquid compressibility factor [-] given the pressure [MPa]"),
+                                        // description of rp_zfp(fluid,p)
+    (LPCFUNCTION)rp_Zfp,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};

--- a/wrappers/Mathcad/includes/rp_zft.h
+++ b/wrappers/Mathcad/includes/rp_zft.h
@@ -1,0 +1,62 @@
+LRESULT rp_Zft(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      t   )
+{
+    char herr[255];
+    int kph = 1;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)  
+    int ierr;
+    int icomp = 1;
+    double psat,tsat,rhol,rhov,xliq[20],xvap[20];
+    double tc, pc, Dc, Rgas, ttrip, tnbpt, Zc, acf, dip;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( t->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tsat = t->real;
+
+    SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
+            return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    // Update sat liquid pressure if mixture
+    PRESSdll(&tsat, &rhol, &x[0], &psat);  // [K], [mol/L], [kPa]
+
+    // Get Rgas
+    if (ncomp > 1)
+    {
+        RMIX2dll(&x[0], &Rgas);              // mixture gas constant [J/mol-K]
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
+
+    ret->real = psat / (Rgas * tsat * rhol);   // calculate compressibility factor
+
+    return 0;               // return 0 to indicate there was no error
+            
+}    
+
+FUNCTIONINFO    rp_zft = 
+{ 
+    (char *)("rp_zft"),                 // Name by which mathcad will recognize the function
+    (char *)("fluid,t"),                // rp_zft will be called as rp_zft(fluid,t)
+    (char *)("Returns the saturation liquid compressibility factor [-] given the temperature [K]"),
+                                        // description of rp_zft(fluid,t)
+    (LPCFUNCTION)rp_Zft,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};

--- a/wrappers/Mathcad/includes/rp_zgp.h
+++ b/wrappers/Mathcad/includes/rp_zgp.h
@@ -1,0 +1,62 @@
+LRESULT rp_Zgp(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      p   )
+{
+    char herr[255];
+    int kph = 2;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
+    int ierr;
+    int icomp = 1;
+    double psat,tsat,rhol,rhov,xliq[20],xvap[20];
+    double tc, pc, Dc, Rgas, ttrip, tnbpt, Zc, acf, dip;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( p->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        psat = p->real * 1000.0;
+
+    SATPdll(&psat,&x[0],&kph,&tsat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 2) || (ierr == 4) || (ierr == 4) || (ierr == 141))
+            return MAKELRESULT(P_OUT_OF_RANGE,2); // Pressure too low | negative | > Pcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    // Update sat vapor temperature if mixture using correct density
+    TSATDdll(&rhov, &x[0], &tsat, &ierr, herr, errormessagelength);
+
+    // Get Rgas
+    if (ncomp > 1)
+    {
+        RMIX2dll(&x[0], &Rgas);              // mixture gas constant [J/mol-K]
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
+
+    ret->real = psat / (Rgas * tsat * rhov);   // calculate compressibility factor
+
+    return 0;               // return 0 to indicate there was no error
+            
+}
+
+FUNCTIONINFO    rp_zgp = 
+{ 
+    (char *)("rp_zgp"),                 // Name by which mathcad will recognize the function
+    (char *)("fluid,p"),                // rp_zgp will be called as rp_zgp(fluid,p)
+    (char *)("Returns the saturation vapor compressibility factor [-] given the pressure [MPa]"),
+                                        // description of rp_zgp(fluid,p)
+    (LPCFUNCTION)rp_Zgp,                // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes 2 arguments
+    { MC_STRING,                        // argument is a MC_STRING
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};

--- a/wrappers/Mathcad/includes/rp_zgt.h
+++ b/wrappers/Mathcad/includes/rp_zgt.h
@@ -1,0 +1,61 @@
+LRESULT rp_Zgt(
+    LPCOMPLEXSCALAR     ret,
+    LPCMCSTRING       fluid,
+    LPCCOMPLEXSCALAR      t   )
+{
+    char herr[255];
+    int kph = 2;       //  kph = 1 (saturated liquid conc.); kph = 2 (saturated vapor conc.)
+    int ierr;
+    int icomp = 1;
+    double psat,tsat,rhol,rhov,xliq[20],xvap[20];
+    double tc, pc, Dc, Rgas, ttrip, tnbpt, Zc, acf, dip;
+
+    ierr = cSetup(fluid->str);
+    if (ierr > 0)
+        return MAKELRESULT(ierr,1);
+    
+    if( t->imag != 0.0 )
+        return MAKELRESULT(MUST_BE_REAL,2);
+    else
+        tsat = t->real;
+
+    SATTdll(&tsat,&x[0],&kph,&psat,&rhol,&rhov,&xliq[0],&xvap[0],&ierr,herr,errormessagelength);
+
+    if (ierr > 0)
+    {
+        if ((ierr == 1)||(ierr == 9)||(ierr == 121)) 
+            return MAKELRESULT(T_OUT_OF_RANGE,2); // Temperature too low | negative | > Tcrit
+        else
+            return MAKELRESULT(UNCONVERGED,2); // failed to converge
+    }
+
+    // Update sat vapor pressure if mixture
+    PRESSdll(&tsat, &rhov, &x[0], &psat);  // [K], [mol/L], [kPa]
+
+    // Get Rgas
+    if (ncomp > 1)
+    {
+        RMIX2dll(&x[0], &Rgas);              // mixture gas constant [J/mol-K]
+    }
+    else
+    {
+        INFOdll(&icomp, &wmm, &ttrip, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
+    }
+
+    ret->real = psat / ( Rgas * tsat * rhov);   // calculate compressibility factor
+
+    return 0;               // return 0 to indicate there was no error
+}
+
+FUNCTIONINFO    rp_zgt = 
+{ 
+    (char *)("rp_zgt"),                          // Name by which mathcad will recognize the function
+    (char *)("fluid,t"),                                // rp_zgt will be called as rp_zgt(fluid,t)
+    (char *)("Returns the saturation vapor compressibility factor [-] given the temperature [K]"),
+                                        // description of rp_zgt(fluid,t)
+    (LPCFUNCTION)rp_Zgt,               // pointer to the executable code
+    COMPLEX_SCALAR,                     // the return type is a complex scalar
+    2,                                  // the function takes on 1 argument
+    { MC_STRING,
+      COMPLEX_SCALAR }                  // argument is a complex scalar
+};


### PR DESCRIPTION
### Description of the Change

Add derived quantity functions to Mathcad wrapper for speed improvement

New functions (general and saturation (f/g) as function of either t, p, or both) follow naming convention of all other thermodynamic functions in the Mathcad wrapper:
1. Prandtl Number (`rp_prtp`, `rp_prft`, `rp_prgt`, `rp_prfp`, `rp_prgp`)
2. Cp/Cv ratio, gamma (`rp_gammatp`, `rp_gammaft`, `rp_gammagt`, `rp_gammafp`, `rp_gammagp`)
3. Thermal Expansion Coefficient, Beta (`rp_betatp`, `rp_betaft`, `rp_betagt`, `rp_betafp`, `rp_betagp`)
4. Compressibility, Z (`rp_ztp`, `rp_zft`, `rp_zgt`, `rp_zfp`, `rp_zgp`, & rp_zcrit)

**Additional Items:**
- Mathcad wrapper version update to 2.0.3.
- Added function `rp_getRPnum` to retrieve the loaded major.minor version of REFPROP loaded as a double.  In preparation for adding REFPROP 10 high-level API functions, his will help Mathcad worksheets and templates be able discern the REFPROP version number and make quick version comparisons (e.g. pre-/post-REFPROP10) when allowing/disallowing high-level API calls.
- Handle significant changes in error codes returned from `TRNPRPdll` between REFPROP 9.1 and REFPROP 10 
- Miscellaneous updates to code comments 

### Benefits

1. Calling these derived quantity functions from the compiled add-in DLL should be slightly faster than performing the underlying calculations natively within Mathcad, especially when called repeatedly.
2. Transport functions now provide correct error handling of codes returned by REFPROP 10.

### Possible Drawbacks

Because the Mathcad unit handling include file (REFPROP_units.mcdx) is a binary file, it has not been updated in this PR, but will be updated to include the above derived quantity functions once the planned REFPROP 10 high-level API functions are added to the Mathcad wrapper.

### Verification Process

- Ran extended regression testing successfully. 
- Ran new verification worksheet ([Derived Test H2O v3.pdf](https://github.com/usnistgov/REFPROP-wrappers/files/9525786/Derived.Test.H2O.v3.pdf)) for quantitative checking against REFPROP values and range checking using both CO2 and H2O fluids.

### Applicable Issues (none)