### PR TITLE
Mathematica Wrapper Units Patch for Mathematica 13.2

### DIFF
--- a/wrappers/Mathematica/PacletInfo.m
+++ b/wrappers/Mathematica/PacletInfo.m
@@ -1,5 +1,3 @@
-(* ::Package:: *)
-
 (* Paclet Info File *)
 
 (* created 2021/10/10*)
@@ -30,3 +28,5 @@ Paclet[
                 }}
         }
 ]
+
+

--- a/wrappers/Mathematica/PacletInfo.m
+++ b/wrappers/Mathematica/PacletInfo.m
@@ -1,10 +1,12 @@
+(* ::Package:: *)
+
 (* Paclet Info File *)
 
 (* created 2021/10/10*)
 
 Paclet[
     Name -> "RefpropLink",
-    Version -> "1.0.5",
+    Version -> "1.0.6",
     WolframVersion -> "12.1+",
     Description -> "Provides wrapper functions for the NIST REFPROP materials library functions.",
     Creator -> "J. P. Henning",
@@ -28,5 +30,3 @@ Paclet[
                 }}
         }
 ]
-
-

--- a/wrappers/Mathematica/RefpropLink/RefpropLink.m
+++ b/wrappers/Mathematica/RefpropLink/RefpropLink.m
@@ -1,8 +1,5 @@
-(* ::Package:: *)
-
 (* ::Section:: *)
 (* Wolfram Language Package *)
-
 
 BeginPackage["RefpropLink`",{"NETLink`", "RefpropLink`RefpropUnits`"}]
 Unprotect @@ Names["RepropLink`*"];
@@ -191,11 +188,8 @@ Begin["`Private`"]
 
 InstallNET[];
 
-
-
 (* ::Section:: *)
 (* Initialization *)
-
 
 (***************************************************************************************)
 (*                            Package initialization                                   *)
@@ -320,30 +314,23 @@ If[ $VersionNumber == 12.2,                     (* ONLY if Mathematica version 1
 (* command below that sets R as an absolute temperature type.                          *)
 (* A permanent fix should be available in 13.3 and this workaround won't be necessary. *)
 (***************************************************************************************)
-If[ $VersionNumber == 13.2,                     (* ONLY if Mathematica version 12.2     *)
+If[ $VersionNumber == 13.2,                     (* ONLY if Mathematica version 13.2    *)
     QuantityUnits`Private`hasNonZeroTempUnitQ["DegreesRankine"]=True;  (*  Workaround  *)
 ];                                              (* Set R as absolute quantity          *)
-
 
 (***************************************************************************************)
 (*                            Package initialization Complete                          *)
 (***************************************************************************************)
 
-
-
 (* ::Section:: *)
 (* Legacy API *)
-
 
 (***************************************************************************************)
 (*                   Define Legacy (Pre-RefProp 10) API Functions                      *)
 (***************************************************************************************)
 
-
-
 (* ::SubSection:: *)
 (* Setup Functions *)
-
 
 $hExts = {"*.FLD", "*.PPF"};
 chkFLD[a_String] := Module[{},
@@ -519,7 +506,6 @@ setref[hRef_String:"???",x0_List:{1.0},h0_:0,s0_:0,T0_:0,P0_:0]:=
 (* ::SubSection:: *)
 (* Utility Functions *)
 
-
 (*************************************************************************************************************************)
 (* Utility Functions                                                                                                     *)
 (*************************************************************************************************************************)
@@ -667,11 +653,8 @@ purefld[icomp_Integer:0]:=
     ]
 
     
-
-
 (* ::SubSection:: *)
 (* Information *)
-
 
 (*************************************************************************************************************************)
 (* Fluid Information Functions                                                                                           *)
@@ -805,11 +788,8 @@ limits[htype_String:"EOS",                        (* Overloaded limits function:
 
 SetAttributes[{info, wmoli, name, longname, casn}, {Listable}];  (* Can be made Listable since don't take a z List.      *)
 
-
-
 (* ::SubSection:: *)
 (* Single Phase *)
-
 
 (*************************************************************************************************************************)
 (* Single Phase Property Functions                                                                                       *)
@@ -935,11 +915,8 @@ cvcp[t_,d_,z_List:{1.0}]:=
         ]
     ]
 
-
-
 (* ::SubSection:: *)
 (* Saturation *)
-
 
 (*************************************************************************************************************************)
 (* Saturation State Functions                                                                                            *)
@@ -1197,11 +1174,8 @@ sath[h_,z_List:{1.0},kph_Integer:0]:=
         ]
     ]
 
-
-
 (* ::Subsection:: *)
 (* 2-Phase *)
-
 
 (*************************************************************************************************************************)
 (* General Flash Calculations                                                                                            *)
@@ -1607,7 +1581,6 @@ psflsh[P_,S_,z_List:{1.0}]:=
 (* ::SubSection:: *)
 (* Transport Props *)
 
-
 (****************************************************************************)
 (* Transport Properties                                                     *)
 (****************************************************************************)
@@ -1722,11 +1695,8 @@ fugacity[t_,d_,z_List:{1.0}]:=
         ]
     ]
 
-
-
 (* ::SubSection:: *)
 (* MELT/SUBLIMATION *)
-
 
 (****************************************************************************)
 (* MELTING and SUBLIMATION curves                                           *)
@@ -1810,11 +1780,8 @@ sublt[t_,z_List:{1.0}]:=                                                 (* Calc
         ]
    ]
 
-
-
 (* ::SubSection:: *)
 (* Compressibility *)
-
 
 (****************************************************************************)
 (* Calculate the virial coefficients as a function of temperature and comp. *)
@@ -1854,11 +1821,8 @@ virial[t_,z_List:{1.0}]:=
     ]
     
 
-
-
 (* ::Section:: *)
 (* REFPROP10 API *)
-
 
 (* Get REFPROP Version Information                                                                               *)
 (*                                                                                                               *)
@@ -2150,11 +2114,8 @@ RefProp[ hFld_String:" ", hIn_String, hOut_String, a_, b_, z_List:{1.0}, Options
 (*                                   End REFPROP 10 API Function Definitions                                     *)
 (*****************************************************************************************************************)
 
-
-
 (* ::Section:: *)
 (* Package Postscript *)
-
 
 End[]           (* END Private Definitions *)
 

--- a/wrappers/Mathematica/RefpropLink/RefpropLink.m
+++ b/wrappers/Mathematica/RefpropLink/RefpropLink.m
@@ -1,5 +1,8 @@
+(* ::Package:: *)
+
 (* ::Section:: *)
 (* Wolfram Language Package *)
+
 
 BeginPackage["RefpropLink`",{"NETLink`", "RefpropLink`RefpropUnits`"}]
 Unprotect @@ Names["RepropLink`*"];
@@ -188,8 +191,11 @@ Begin["`Private`"]
 
 InstallNET[];
 
+
+
 (* ::Section:: *)
 (* Initialization *)
+
 
 (***************************************************************************************)
 (*                            Package initialization                                   *)
@@ -307,18 +313,37 @@ If[ $VersionNumber == 12.2,                     (* ONLY if Mathematica version 1
 ];                                              (*   for all calls of ValueQ           *)
 
 (***************************************************************************************)
+(*               Mathematica 13.2 fix for R ("DegreesRankine") Units                   *)
+(* This is a workaround provided by Wolfram.  It appears that a change in the delta    *)
+(* temperature units causes "DegreesRankine" to be handled as a non-absolute quantity. *)
+(* For version 13.2, the legacy behavior in the code can be activated by with the      *)
+(* command below that sets R as an absolute temperature type.                          *)
+(* A permanent fix should be available in 13.3 and this workaround won't be necessary. *)
+(***************************************************************************************)
+If[ $VersionNumber == 13.2,                     (* ONLY if Mathematica version 12.2     *)
+    QuantityUnits`Private`hasNonZeroTempUnitQ["DegreesRankine"]=True;  (*  Workaround  *)
+];                                              (* Set R as absolute quantity          *)
+
+
+(***************************************************************************************)
 (*                            Package initialization Complete                          *)
 (***************************************************************************************)
 
+
+
 (* ::Section:: *)
 (* Legacy API *)
+
 
 (***************************************************************************************)
 (*                   Define Legacy (Pre-RefProp 10) API Functions                      *)
 (***************************************************************************************)
 
+
+
 (* ::SubSection:: *)
 (* Setup Functions *)
+
 
 $hExts = {"*.FLD", "*.PPF"};
 chkFLD[a_String] := Module[{},
@@ -494,6 +519,7 @@ setref[hRef_String:"???",x0_List:{1.0},h0_:0,s0_:0,T0_:0,P0_:0]:=
 (* ::SubSection:: *)
 (* Utility Functions *)
 
+
 (*************************************************************************************************************************)
 (* Utility Functions                                                                                                     *)
 (*************************************************************************************************************************)
@@ -641,8 +667,11 @@ purefld[icomp_Integer:0]:=
     ]
 
     
+
+
 (* ::SubSection:: *)
 (* Information *)
+
 
 (*************************************************************************************************************************)
 (* Fluid Information Functions                                                                                           *)
@@ -776,8 +805,11 @@ limits[htype_String:"EOS",                        (* Overloaded limits function:
 
 SetAttributes[{info, wmoli, name, longname, casn}, {Listable}];  (* Can be made Listable since don't take a z List.      *)
 
+
+
 (* ::SubSection:: *)
 (* Single Phase *)
+
 
 (*************************************************************************************************************************)
 (* Single Phase Property Functions                                                                                       *)
@@ -903,8 +935,11 @@ cvcp[t_,d_,z_List:{1.0}]:=
         ]
     ]
 
+
+
 (* ::SubSection:: *)
 (* Saturation *)
+
 
 (*************************************************************************************************************************)
 (* Saturation State Functions                                                                                            *)
@@ -1162,8 +1197,11 @@ sath[h_,z_List:{1.0},kph_Integer:0]:=
         ]
     ]
 
+
+
 (* ::Subsection:: *)
 (* 2-Phase *)
+
 
 (*************************************************************************************************************************)
 (* General Flash Calculations                                                                                            *)
@@ -1569,6 +1607,7 @@ psflsh[P_,S_,z_List:{1.0}]:=
 (* ::SubSection:: *)
 (* Transport Props *)
 
+
 (****************************************************************************)
 (* Transport Properties                                                     *)
 (****************************************************************************)
@@ -1683,8 +1722,11 @@ fugacity[t_,d_,z_List:{1.0}]:=
         ]
     ]
 
+
+
 (* ::SubSection:: *)
 (* MELT/SUBLIMATION *)
+
 
 (****************************************************************************)
 (* MELTING and SUBLIMATION curves                                           *)
@@ -1768,8 +1810,11 @@ sublt[t_,z_List:{1.0}]:=                                                 (* Calc
         ]
    ]
 
+
+
 (* ::SubSection:: *)
 (* Compressibility *)
+
 
 (****************************************************************************)
 (* Calculate the virial coefficients as a function of temperature and comp. *)
@@ -1809,8 +1854,11 @@ virial[t_,z_List:{1.0}]:=
     ]
     
 
+
+
 (* ::Section:: *)
 (* REFPROP10 API *)
+
 
 (* Get REFPROP Version Information                                                                               *)
 (*                                                                                                               *)
@@ -2102,8 +2150,11 @@ RefProp[ hFld_String:" ", hIn_String, hOut_String, a_, b_, z_List:{1.0}, Options
 (*                                   End REFPROP 10 API Function Definitions                                     *)
 (*****************************************************************************************************************)
 
+
+
 (* ::Section:: *)
 (* Package Postscript *)
+
 
 End[]           (* END Private Definitions *)
 

--- a/wrappers/Mathematica/RefpropLink/RefpropUnits.m
+++ b/wrappers/Mathematica/RefpropLink/RefpropUnits.m
@@ -1,5 +1,3 @@
-(* ::Package:: *)
-
 (* Wolfram Language Package *)
 
 BeginPackage["RefpropLink`RefpropUnits`"]
@@ -149,12 +147,12 @@ inHg = Quantity[1., "InchesOfMercury"];
 inH2O = Quantity[1., "InchesOfWaterColumn"];
 
 (*** Temperature ***)
-(* \[Degree]F and \[Degree]C removed due to fundamental change in unit handling as of Mathematica *)
+(* °F and °C removed due to fundamental change in unit handling as of Mathematica *)
 (* version 13.2; Affine temperatures must be set by user using the Quantity[] function. *)                    
-If[ $VersionNumber < 13.2, \[Degree]F = Quantity[1., "DegreesFahrenheit"]];
+If [ $VersionNumber < 13.2, \[Degree]F = Quantity[1., "DegreesFahrenheit"]];
 R = Quantity[1., "DegreesRankine"];
 K = Quantity[1., "Kelvins"];
-If[ $VersionNumber < 13.2, \[Degree]C = Quantity[1., "DegreesCelsius"]];
+If [ $VersionNumber < 13.2, \[Degree]C = Quantity[1., "DegreesCelsius"]];
 
 (*** Molar Quantities ***)
 mol = Quantity[1., "Moles"];

--- a/wrappers/Mathematica/RefpropLink/RefpropUnits.m
+++ b/wrappers/Mathematica/RefpropLink/RefpropUnits.m
@@ -128,7 +128,7 @@ lb = Quantity[1., "Pounds"];
 
 (*** Force Units ***)
 Newton = Quantity[1., "Newtons"];
-mN = Quantity[0.001, "Millinewtons"];   (* Fixes functionality in MM v13.2 *)
+mN = Quantity[1., "Millinewtons"];   (* Fixes functionality in MM v13.2 *)
 lbf = Quantity[1., "PoundsForce"];
 
 (*** Pressure  ***)

--- a/wrappers/Mathematica/RefpropLink/RefpropUnits.m
+++ b/wrappers/Mathematica/RefpropLink/RefpropUnits.m
@@ -1,3 +1,5 @@
+(* ::Package:: *)
+
 (* Wolfram Language Package *)
 
 BeginPackage["RefpropLink`RefpropUnits`"]
@@ -58,10 +60,10 @@ mmHg::usage = "millimeters of mercury"
 inHg::usage = "inches of mercury"
 inH2O::usage = "inches of water"
 (*** Temperature ***)
-\[Degree]F::usage = "degrees Fahrenheit"
+\[Degree]F::usage = "degrees Fahrenheit - Obsolete as of Mathematica 13.2"
 \[Degree]R::usage = "degrees Rankin"
 \[Degree]K::usage = "degree Kelvin"
-\[Degree]C::usage = "degrees Celsius"
+\[Degree]C::usage = "degrees Celsius - Obsolete as of Mathematica 13.2"
 (*** Molar Quantities ***)
 mol::usage = "moles"
 kmol::usage = "kilomoles"
@@ -128,7 +130,7 @@ lb = Quantity[1., "Pounds"];
 
 (*** Force Units ***)
 Newton = Quantity[1., "Newtons"];
-mN = Quantity[0.001, Newton];
+mN = Quantity[0.001, "Millinewtons"];   (* Fixes functionality in MM v13.2 *)
 lbf = Quantity[1., "PoundsForce"];
 
 (*** Pressure  ***)
@@ -147,10 +149,12 @@ inHg = Quantity[1., "InchesOfMercury"];
 inH2O = Quantity[1., "InchesOfWaterColumn"];
 
 (*** Temperature ***)
-\[Degree]F = Quantity[1., "DegreesFahrenheit"];
+(* \[Degree]F and \[Degree]C removed due to fundamental change in unit handling as of Mathematica *)
+(* version 13.2; Affine temperatures must be set by user using the Quantity[] function. *)                    
+If[ $VersionNumber < 13.2, \[Degree]F = Quantity[1., "DegreesFahrenheit"]];
 R = Quantity[1., "DegreesRankine"];
 K = Quantity[1., "Kelvins"];
-\[Degree]C = Quantity[1., "DegreesCelsius"];
+If[ $VersionNumber < 13.2, \[Degree]C = Quantity[1., "DegreesCelsius"]];
 
 (*** Molar Quantities ***)
 mol = Quantity[1., "Moles"];

--- a/wrappers/Mathematica/build/RefpropLink/PacletInfo.m
+++ b/wrappers/Mathematica/build/RefpropLink/PacletInfo.m
@@ -1,5 +1,3 @@
-(* ::Package:: *)
-
 (* Paclet Info File *)
 
 (* created 2021/10/10*)
@@ -30,3 +28,5 @@ Paclet[
                 }}
         }
 ]
+
+

--- a/wrappers/Mathematica/build/RefpropLink/PacletInfo.m
+++ b/wrappers/Mathematica/build/RefpropLink/PacletInfo.m
@@ -1,10 +1,12 @@
+(* ::Package:: *)
+
 (* Paclet Info File *)
 
 (* created 2021/10/10*)
 
 Paclet[
     Name -> "RefpropLink",
-    Version -> "1.0.5",
+    Version -> "1.0.6",
     WolframVersion -> "12.1+",
     Description -> "Provides wrapper functions for the NIST REFPROP materials library functions.",
     Creator -> "J. P. Henning",
@@ -28,5 +30,3 @@ Paclet[
                 }}
         }
 ]
-
-


### PR DESCRIPTION
### Description of the Change

Mathematica 13.2 introduced some changes in unit handling that created errors in the Mathematica Wrapper.  These have been patched including:
- On loading of RefpropLink, an error occurs on the definition of the mN unit.
- Mathematica bug treats Rankine (R) unit as a temperature change unit instead of an absolute unit.  Wolfram will provide a patch release, but provided an interim work around that is applied when RefpropLink loads, but only if $VersionNumber = 13.2
- There is a fundamental change in how Mathematica handles multiplication of affine temperature units (°F and °C).  The change is warranted, but RefpropLink took advantage of the previously inconsistent treatment to create temperature unit variables °F and °C for simply temperature input notation.  These unit variables have been removed for all versions > 13.2.

### Benefits

Eliminates error message when loading the RefpropLink wrapper paclet, and when converting between Rankine and other temperature units.  Also deprecates the affine temperature scaling variable definitions for °F and °C.

### Possible Drawbacks

Temperatures with affine units must now be entered using Mathematica's `Quantity[ ]` function.

```WL
    T = Quantity[72.0, "DegreesFahrenheit"]
    T2 = Quantity[22.0, "DegreesCelsius"]
```

Also, extensive documentation still uses the provided °F and °C unit variables.  However, an upcoming PR to address #502 will correct this misuse of °F and °C in the overhauled documentation  files.

### Verification Process

Changes were rather simple and can be viewed in the file changes.  However, documentation examples were re-run and did not show any errors.

### Applicable Issues

Closes #495