### PR TITLE
Mathcad Wrapper: README Updates

### DIFF
--- a/wrappers/Mathcad/High-LevelAPI.md
+++ b/wrappers/Mathcad/High-LevelAPI.md
@@ -2,21 +2,21 @@
 
 The High-Level API calls were introduced in NIST REFPROP 10 and wrappers for this functions are introduced in the RefProp Mathcad Add-in version 2.1.  The following High-Level API functions are implemented (in alphabetical order).
 
-* rp_ERRMSG(0) - Retrieves full error messages from NIST REFPROP for the last function call
-* rp_FLAGS(_hFlag_, _jFlag_) - Set (and get) flags that modify NIST REFPROP behavior
-* rp_GETENUM(_iFlag_, _hEnum_) - Get enumerated values for various REFPROP inputs
-* rp_REFPROP(_hFld_, _hIn_, _hOut_, _a_, _b_) - General REFPROP() call; returns an array of numeric values
-* rp_REFPROP1(_hIn_, _hOut_, _a_, _b_) - Shortened REFPROP() call; returns single scalar values
-* rp_REFPROPc(_hFld_, _hIn_, _hOut_, _a_, _b_) - Special REFPROP() call for returning character data 
-* rp_SETFLUIDS(_hFld_) - Loads specified pure fluid(s) from the REFPROP library
-* rp_SETMIXTURE(_hMixNme_) - Loads pre-defined mixtures from the REFPROP library, returning composition.
-* rp_SETPATH(_hPath_) - Sets the path to an alternate location for the fluid/mixture files
+* **rp_ERRMSG(0)** - Retrieves full error messages from NIST REFPROP for the last function call
+* **rp_FLAGS(_hFlag_, _jFlag_)** - Set (and get) flags that modify NIST REFPROP behavior
+* **rp_GETENUM(_iFlag_, _hEnum_)** - Get enumerated values for various REFPROP inputs
+* **rp_REFPROP(_hFld_, _hIn_, _hOut_, _a_, _b_)** - General REFPROP() call; returns an array of numeric values
+* **rp_REFPROP1(_hIn_, _hOut_, _a_, _b_)** - Shortened REFPROP() call; returns single scalar values
+* **rp_REFPROPc(_hFld_, _hIn_, _hOut_, _a_, _b_)** - Special REFPROP() call for returning character data 
+* **rp_SETFLUIDS(_hFld_)** - Loads specified pure fluid(s) from the REFPROP library
+* **rp_SETMIXTURE(_hMixNme_)** - Loads pre-defined mixtures from the REFPROP library, returning composition.
+* **rp_SETPATH(_hPath_)** - Sets the path to an alternate location for the fluid/mixture files
 
 ## REFPROP()
 
-The REFPROP function was created in the High-Level API to provide a single function through which all properties and fluid/mixture information could be retrieved.  It is the Swiss Army knife of the NIST REFPROP library.  In addition, various flags are available that can be sent to this routine to gain access to all other features and settings of the REFPROP program.  For full documentation of its use, one should consult the NIST REFPROP DLL Documentation.
+The REFPROP function was created in the High-Level API to provide a single function through which all properties and fluid/mixture information could be retrieved.  It is the Swiss Army knife of the NIST REFPROP library.  In addition, various flags are available that can be sent to this routine to gain access to all other features and settings of the REFPROP program.  For full documentation of its use, one should consult the [NIST REFPROP DLL Documentation](https://refprop-docs.readthedocs.io/en/latest/DLL/index.html).
 
-In the NIST REFPROP DLL, there are actually three versions of the REFPROP public function and the Mathcad Custom function(s) make the determination on which one to call. However, because of the limitation of Mathcad Custom Functions to return only one data type, the call to the REFPROP functions has been broken up into three functions:
+Because of the limitation of Mathcad Custom Functions to return only one data type, the calls to the REFPROP functions has been broken up into three add-in functions:
 
 1. **rp_REFPROP()** - Standard call that can only return (and always returns) numeric values in a numeric array.  This form always requires a fluid string as the first parameter (as does the underlying REFPROP() function).  However, if called more than once with the same fluid string, it will be ignored on multiple calls.   If empty (""), the previously loaded fluid will be used as well.  
 
@@ -24,11 +24,13 @@ In the NIST REFPROP DLL, there are actually three versions of the REFPROP public
 
 3. **rp_REFPROPc()** - The same as rp_REFPROP, except that only a single character string can be returned.  Requires a fluid string, but it can be blank to use previously loaded fluid.
 
-All three rp_REFPROP function variations, in addition to a fluid string, require the following input parameters:
+All three rp_REFPROP function variations require the following input parameters:
 - **_hIn_** - Single string containing the property codes to identify the state-point pair of variables passed in _a_ and _b_.  May be an empty string ("") for state-point independent property requests.  (_See [NIST REFPROP DLL Documentation for REFPROPdll](https://refprop-docs.readthedocs.io/en/latest/DLL/high_level.html#f/_/REFPROPdll) for a full listing of valid codes_)
 - **_hOut_** - Single delimited string containing the codes for the requested output properties. (_see [NIST REFPROP DLL Documentation for ALLPROPSdll](https://refprop-docs.readthedocs.io/en/latest/DLL/high_level.html#f/_/ALLPROPSdll) for a full listing of valid codes_) 
 - **_a_** - First state-point value.  May be 0 or arbitrary if not required.
 - **_b_** - Second state-point value. May be 0 or arbitrary if not required.
+
+However, **rp_REFPROP()** and **rp_REFPROPc()** also require a fluid string, **_hFld_**, as the first parameter, before the others mentioned above.
 
 Attempts have been made to greatly simplify these Mathcad Custom Functions as much as possible so that they require a maximum of four or five input parameters.  Simplifications include:
 * Input/Output units are _always_ "MASS SI" with slight modification to Thermal Conductivity [W/m-K] and Surface Tension [N/m] for consistency with the Legacy API custom functions.  This can be changed with the proper calls, but it not recommended, since Mathcad can easily handle unit conversions natively and the special REFPROP() unit wrapper expects this system of units.
@@ -36,7 +38,7 @@ Attempts have been made to greatly simplify these Mathcad Custom Functions as mu
 * The mixture composition, _z_, is maintained and handled internally by the Custom Function DLL as fluids and mixtures are loaded.
 * All other _output_ parameters are superfluous as they can be requested in _hOut_ and returned in the _Output_ array.  
 
-Finally, while the above functions can be called with unitless parameters and output, a single user function, `REFPROP(hFld,hIn,hOut,a,b)`, is provided in the `Refprop_units.mcdx` include file that automatically makes the determination on which custom function to call, provides better error handling, and handles Mathcad units on the inputs and numeric output values.  The `Refprop_units.mcdx` include file can be located in the same location as the active Mathcad worksheet or in a convenient shared location. Here is a Mathcad example of using the High-Level function, `REFPROP(hFld,hIn,hOut,a,b)`, through the unit wrapper function.
+Finally, while the above functions can be called with dimensionless parameters and output, a single user function, `REFPROP(hFld,hIn,hOut,a,b)`, is provided in the `Refprop_units.mcdx` include file that automatically makes the determination on which custom function to call, provides better error handling, and handles Mathcad units on the inputs and numeric output values.  The `Refprop_units.mcdx` include file can be located in the same location as the active Mathcad worksheet or in a convenient shared location. Here is a Mathcad example of using the High-Level function, `REFPROP(hFld,hIn,hOut,a,b)`, through the unit wrapper function.
 
 ![Example Screenshot](img/Screenshot-HLUnits.png "High-Level Units Screenshot")
 
@@ -46,7 +48,7 @@ The remaining implemented functions are utility functions that access the other 
 
 ## Other Considerations
 
-Consideration was given to implementation of the `ALLPROPSdll` function and its variations in the High-Level API.  However, it is not implemented as there are no advantages to using it over the `REFPROP()` function, which provides greater functionality, handles both single and two-phase states, and is not limited to Temperature and Density (TD) state point specification.  The `ALLPROPS0dll` function may provide some performance benefits (does not use any string manipulation), but it is still limited to single-phase, temperature-density state points, fixed default units, and it was determined that any performance benefits were consumed in providing pre and post-processing of inputs and results in Mathcad itself.
+Consideration was given to implementation of the `ALLPROPSdll` function and its variations in the High-Level API.  However, it is not implemented as there are no advantages to using it over the `REFPROP()` function, which provides greater functionality, handles both single and two-phase states, and is not limited to Temperature and Density (TD) state point specification.  The `ALLPROPS0dll` function may provide some performance benefits (does not use any string manipulation), but it is still limited to single-phase, temperature-density state points, fixed default units, and it is provided as a "beta features" until a determination is made that any performance benefits are not consumed in providing pre and post-processing of inputs and results in Mathcad itself.
 
 Additional consideration was given to implementation of the `ABFLSHdll` function for providing generic flash calculations in the two-phase region.  However, this functionality is provided through the REFPROP() functions and, in fact, the underlying `REFPROP()` function code makes calls directly to `ABFLSH()` to make its phase determinations.  If computational speed is of the essence, the low-level [Legacy API](LegacyAPI.md) functions should be called, which are already implemented as Mathcad Custom Functions.
 

--- a/wrappers/Mathcad/README.md
+++ b/wrappers/Mathcad/README.md
@@ -8,6 +8,8 @@ The Mathcad wrapper provides a diverse range of add-in functions (all beginning 
 
 This repository contains the source for building the Mathcad Prime and/or Legacy Mathcad wrappers for the NIST REFPROP materials library using a community or professional version of Microsoft Visual Studio with Visual C++.   This wrapper code, starting with version 2.0, uses [REFPROP-headers](https://github.com/CoolProp/REFPROP-headers) to make calls directly to the Legacy API functions in REFPROP.dll (or REFPRP64.dll) when NIST REFPROP 9.1 or later is installed.  Version 2.1 contains significant enhancements to implement the High-Level API when NIST REFPROP 10.0 or later is installed.  PTC Mathcad only runs on the MS Windows platform. 
 
+> **NOTE:** _The precompiled Custom Function DLL is now available [below](#installing-the-pre-compiled-dll-for-mathcad-prime)_!
+
 ------
 
 ## Prerequisites
@@ -15,17 +17,31 @@ This repository contains the source for building the Mathcad Prime and/or Legacy
 The prerequisites for building and running the REFPROP add-in for Mathcad are:  
   
 1. Mathcad Prime (tested up to version 8.0.0.0) (_see NOTE_)
-2. MS Visual Studio 2015 or later (_Professional or Community editions_)
-3. NIST REFPROP 9.1 or later ( _available from [NIST](https://www.nist.gov/srd/refprop)_ ), but REFPROP 10 is preferred  
+2. NIST REFPROP 9.1 or later ( _available from [NIST](https://www.nist.gov/srd/refprop)_ ), but REFPROP 10 is preferred
+3. MS Visual Studio 2015 or later (_Professional or Community editions_)  
+    **_<u>Only needed if Compiling (Buiding) the Add-In DLL</u>_**
 
-The ability to download a pre-compiled windows DLL is being investigated, eliminating the second requirement above.
+If downloading the pre-compiled windows DLL, the third requirement above is not needed.
 
-    NOTE: While Legacy Mathcad 15 is no longer supported or distributed by PTC, 32-bit versions of this library can still be built for those who still have perpetual licenses of Mathcad 15.  However, compilation for Mathcad 15 is no longer being tested nor supported or developed.
+> NOTE: While Legacy Mathcad 15 is no longer supported or distributed by PTC, 32-bit versions of this library can still be built for those who still have perpetual licenses of Legacy Mathcad (15 or earlier). However, compilation for Mathcad 15 is no longer being tested nor supported or  developed.  
+
 ------
 
-## Building the Mathcad Prime Custom Function DLL
+# Installing the Pre-compiled DLL for Mathcad Prime
 
-To build the Mathcad Prime DLL,
+If you just want to download and run the latest wrapper version in Mathcad Prime:
+
+1. Download the latest DLL file by clicking on the file name here [PrimeREFPROPWrapper.dll](https://nist-srd.s3.amazonaws.com/SRD23/MathCAD/PrimeREFPROPWrapper.dll).
+2. Once you have [PrimeREFPROPWrapper.DLL](https://nist-srd.s3.amazonaws.com/SRD23/MathCAD/PrimeREFPROPWrapper.dll) on your computer, copy it to the Mathcad Prime Custom Functions folder, usually located at: `C:\Program Files\PTC\Mathcad Prime 8.0.0.0\Custom Functions`  
+    - Modify `8.0.0.0` if you have a different version, say `7.0.0.0`.  
+    - This may require admin access to your C:\ drive on hardened Windows systems.
+3. Download the the add-in documentation ([Mathcad Prime PDF User's Guide](./PrimeDocs/PrimeManual.pdf)) for reference; as well as referring to the on-line [NIST REFPROP DLL documentation](https://refprop-docs.readthedocs.io/en/latest/DLL/index.html) or your local PDF version installed with **NIST REFPROP**.
+
+------
+
+# Building the Mathcad Custom Function DLL
+
+## Building the **Mathcad Prime** DLL
 
 1. Make sure that Mathcad Prime is not running
 2. Go to the /buildPrime directory
@@ -42,13 +58,13 @@ If you have a newer version than **Mathcad Prime 8.0.0.0**, you will need to mod
 
 to change the applicable `PTC\Mathcad Prime 8.0.0.0` path strings to the appropriate version for your system.
 
-## Building the Legacy Mathcad 15 (unsupported) add-in DLL
+## Building the **Legacy Mathcad 15** (unsupported) add-in DLL
 
 One can also use the same code to [build a 32-bit add-in for Legacy Mathcad](BuildLegacyMathcadDLL.md), however, that functionality is no longer tested or supported.  Use at your own risk.
 
 ------
 
-## Using the RefProp Add-in in Mathcad Prime
+# Using the RefProp Add-in in Mathcad Prime
 
 With the Mathcad wrapper DLL compiled and copied to the appropriate Mathcad directories, the RefProp functions, which all begin with the prefix "rp_", will be directly available for use in Mathcad.  Unfortunately, Mathcad Prime does not yet have the facility to list custom functions as of Mathcad Prime 8.0.  A User's Guide for Mathcad Prime can be found in PDF format in the PrimeDocs folder of this repository.
   

--- a/wrappers/Mathcad/README.md
+++ b/wrappers/Mathcad/README.md
@@ -35,7 +35,10 @@ If you just want to download and run the latest wrapper version in Mathcad Prime
 2. Once you have [PrimeREFPROPWrapper.DLL](https://nist-srd.s3.amazonaws.com/SRD23/MathCAD/PrimeREFPROPWrapper.dll) on your computer, copy it to the Mathcad Prime Custom Functions folder, usually located at: `C:\Program Files\PTC\Mathcad Prime 8.0.0.0\Custom Functions`  
     - Modify `8.0.0.0` if you have a different version, say `7.0.0.0`.  
     - This may require admin access to your C:\ drive on hardened Windows systems.
-3. Download the the add-in documentation ([Mathcad Prime PDF User's Guide](./PrimeDocs/PrimeManual.pdf)) for reference; as well as referring to the on-line [NIST REFPROP DLL documentation](https://refprop-docs.readthedocs.io/en/latest/DLL/index.html) or your local PDF version installed with **NIST REFPROP**.
+3. Download the Mathcad Prime **_include_** file [Refprop_Units.mcdx](https://github.com/usnistgov/REFPROP-wrappers/raw/master/wrappers/Mathcad/Units/RefProp_units.mcdx), which will provide unit handling functions and simplifications for easier access to the REFPROP High-Level API and Legacy API functions.
+4. Download the the add-in documentation ([Mathcad Prime PDF User's Guide](https://github.com/usnistgov/REFPROP-wrappers/raw/master/wrappers/Mathcad/PrimeDocs/PrimeManual.pdf)) for reference.  
+5. Refer to the on-line [NIST REFPROP DLL documentation](https://refprop-docs.readthedocs.io/en/latest/DLL/index.html) or your local PDF version installed with **NIST REFPROP** for more detailed guidance on input/output parameters of the REFPROP API functions.
+
 
 ------
 
@@ -73,7 +76,7 @@ In addition, the file `Units\RefProp_Units.mcdx` is available in Mathcad Prime f
 - Unit handling to convert any parameters to the correct units and return values with units already applied, and
 - Automatic handling of the Output array, single value returns, and string results from the High-Level API functions available with REFPROP 10.
 
-See the add-in documentation ([Mathcad Prime PDF User's Guide](./PrimeDocs/PrimeManual.pdf)) as well as the [NIST REFPROP DLL documentation](https://refprop-docs.readthedocs.io/en/latest/DLL/index.html) for instructions on using these functions.  As of version 2.1 of this add-in, functions are provided for both the
+See the add-in documentation ([Mathcad Prime PDF User's Guide](https://github.com/usnistgov/REFPROP-wrappers/raw/master/wrappers/Mathcad/PrimeDocs/PrimeManual.pdf)) as well as the [NIST REFPROP DLL documentation](https://refprop-docs.readthedocs.io/en/latest/DLL/index.html) for instructions on using these functions.  As of version 2.1 of this add-in, functions are provided for both the
 
 * [High-Level API](High-LevelAPI.md) function calls from REFPROP 10 or later, and  
 
@@ -82,7 +85,8 @@ See the add-in documentation ([Mathcad Prime PDF User's Guide](./PrimeDocs/Prime
 ------
 ## Possible Future Enhancements
 
-1. Add a CMake build system to dynamically create the \build15 and \buildPrime directories, taking Mathcad and VS versions as parameters for a simpler build.
+1. Add a CMake build system to dynamically create the \build15 and \buildPrime directories, taking Mathcad and VS versions as parameters for a simpler build.  
+
 2. Use CMake `find_package()` functionality to automatically find the latest version of Mathcad on the user's machine, simplifying path setting to includes/libraries and the target Custom Functions directory.
 
 ------


### PR DESCRIPTION
Documents new ability to directly download the pre-compiled Mathcad Prime Add-In DLL and provides links to do so, in addition to direct download links for the Add-in PDF Manual and the Units-capable include file, needed for full functionality of the Add-in DLL.