### PR TITLE
Update C++ wrapper including CMake build

### DIFF
--- a/wrappers/C_CPP/CMakeLists.txt
+++ b/wrappers/C_CPP/CMakeLists.txt
@@ -6,6 +6,7 @@ set(MAKE_CXX_STANDARD_REQUIRED ON)
 
 # ---- Download REFPROP C/C++ wrappers ----------------
 set(REPO_URL "https://github.com/usnistgov/REFPROP-wrappers.git")
+set(REPO_BRANCH "master")
 set(REPO_SUBFOLDER "wrappers/C_CPP/refprop")
 set(LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/refprop")
 if(NOT EXISTS ${LOCAL_DIR})
@@ -15,7 +16,7 @@ if(NOT EXISTS ${LOCAL_DIR})
   execute_process(COMMAND git remote add origin ${REPO_URL} WORKING_DIRECTORY ${LOCAL_DIR})
   execute_process(COMMAND git config core.sparseCheckout true WORKING_DIRECTORY ${LOCAL_DIR})
   file(WRITE "${LOCAL_DIR}/.git/info/sparse-checkout" "${REPO_SUBFOLDER}\n")
-  execute_process(COMMAND git pull origin master WORKING_DIRECTORY ${LOCAL_DIR})
+  execute_process(COMMAND git pull origin ${REPO_BRANCH} WORKING_DIRECTORY ${LOCAL_DIR})
 endif()
 add_subdirectory(${LOCAL_DIR}/${REPO_SUBFOLDER})
 

--- a/wrappers/C_CPP/CMakeLists.txt
+++ b/wrappers/C_CPP/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.26)
+project(MyProject)
+
+set(CMAKE_CXX_STANDARD 11)
+set(MAKE_CXX_STANDARD_REQUIRED ON)
+
+# ---- Download REFPROP C/C++ wrappers ----------------
+set(REPO_URL "https://github.com/usnistgov/REFPROP-wrappers.git")
+set(REPO_SUBFOLDER "wrappers/C_CPP/refprop")
+set(LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/refprop")
+if(NOT EXISTS ${LOCAL_DIR})
+  message(STATUS "Downloading REFPROP wrappers")
+  file(MAKE_DIRECTORY ${LOCAL_DIR})
+  execute_process(COMMAND git init WORKING_DIRECTORY ${LOCAL_DIR})
+  execute_process(COMMAND git remote add origin ${REPO_URL} WORKING_DIRECTORY ${LOCAL_DIR})
+  execute_process(COMMAND git config core.sparseCheckout true WORKING_DIRECTORY ${LOCAL_DIR})
+  file(WRITE "${LOCAL_DIR}/.git/info/sparse-checkout" "${REPO_SUBFOLDER}\n")
+  execute_process(COMMAND git pull origin master WORKING_DIRECTORY ${LOCAL_DIR})
+endif()
+add_subdirectory(${LOCAL_DIR}/${REPO_SUBFOLDER})
+
+# Add executable
+set(HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+include_directories(${HEADER_DIR}/${PROJECT_NAME})
+file(GLOB_RECURSE HEADER_FILES "${HEADER_DIR}/*.h")
+set(SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp")
+add_executable(myproject ${HEADER_FILES} ${SOURCE_FILES})
+target_link_libraries(myproject refprop)
+
+# Set output and build directories
+set_target_properties(myproject PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/build")
+
+# ---- Configure Microsoft Visual Studio ----------------
+if(MSVC)
+  # Set configurations
+  set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Debug and Release Builds Configured" FORCE)
+
+  # Choose appropriate version
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
+  
+  # Set the startup project for Visual Studio
+  set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT myproject)
+endif()

--- a/wrappers/C_CPP/CMakeLists.txt
+++ b/wrappers/C_CPP/CMakeLists.txt
@@ -30,6 +30,10 @@ endif()
 FetchContent_Populate(refprop)
 add_subdirectory(${LOCAL_DIR}/${REPO_SUBFOLDER})
 
+# Copy example include and source directories to top-level
+file(COPY "${LOCAL_DIR}/${REPO_SUBFOLDER}/../include" DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
+file(COPY "${LOCAL_DIR}/${REPO_SUBFOLDER}/../src" DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
+
 # Add executable
 set(HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 include_directories(${HEADER_DIR}/${PROJECT_NAME})

--- a/wrappers/C_CPP/CMakeLists.txt
+++ b/wrappers/C_CPP/CMakeLists.txt
@@ -48,9 +48,6 @@ set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/build")
 
 # ---- Configure Microsoft Visual Studio ----------------
 if(MSVC)
-  # Set configurations
-  set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Debug and Release Builds Configured" FORCE)
-
   # Choose appropriate version
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")

--- a/wrappers/C_CPP/CMakeLists.txt
+++ b/wrappers/C_CPP/CMakeLists.txt
@@ -9,15 +9,25 @@ set(REPO_URL "https://github.com/usnistgov/REFPROP-wrappers.git")
 set(REPO_BRANCH "master")
 set(REPO_SUBFOLDER "wrappers/C_CPP/refprop")
 set(LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/refprop")
-if(NOT EXISTS ${LOCAL_DIR})
-  message(STATUS "Downloading REFPROP wrappers")
-  file(MAKE_DIRECTORY ${LOCAL_DIR})
-  execute_process(COMMAND git init WORKING_DIRECTORY ${LOCAL_DIR})
-  execute_process(COMMAND git remote add origin ${REPO_URL} WORKING_DIRECTORY ${LOCAL_DIR})
-  execute_process(COMMAND git config core.sparseCheckout true WORKING_DIRECTORY ${LOCAL_DIR})
-  file(WRITE "${LOCAL_DIR}/.git/info/sparse-checkout" "${REPO_SUBFOLDER}\n")
-  execute_process(COMMAND git pull origin ${REPO_BRANCH} WORKING_DIRECTORY ${LOCAL_DIR})
+include(FetchContent)
+if(EXISTS ${LOCAL_DIR})
+  # Use previously downloaded repo
+  FetchContent_Declare(
+    refprop
+	SOURCE_DIR ${LOCAL_DIR}
+  )
+else()
+  # Download repo
+  message(STATUS "Downloading REFPROP C++ wrapper")
+  FetchContent_Declare(
+    refprop
+    GIT_REPOSITORY ${REPO_URL}
+	GIT_TAG ${REPO_BRANCH}
+    GIT_SHALLOW TRUE                    # TRUE=retrieve only latest commit in tree
+    SOURCE_DIR ${LOCAL_DIR}             # local destination turned source directory
+  )
 endif()
+FetchContent_Populate(refprop)
 add_subdirectory(${LOCAL_DIR}/${REPO_SUBFOLDER})
 
 # Add executable

--- a/wrappers/C_CPP/README.md
+++ b/wrappers/C_CPP/README.md
@@ -15,8 +15,7 @@ Installation
    3. Launch the installer and select the "C++ build tools" workload, ensuring that the MSVC compiler, Windows SDK and C++ Standard Library are included.
    4. Complete the installation.
 7. Download the top-level `CMakeLists.txt` file into a directory that will be used for building the wrapper and associated code.
-8. Download the example code from the `/src` and `/include` directories into the same local directories.
-9. Run CMake from this directory to generate the build files.
+8. Run CMake from this directory to generate the build files.
    1. For Visual Studio on Windows, this can be accomplished by creating and running the following batch file (e.g., `build.bat`).
       ```
       rmdir /Q/S build
@@ -27,8 +26,9 @@ Installation
    
       pause
       ```
-   2. This will download the files in `/refprop` as part of its build process.
-10. Open the `main.cpp` file in the `/src` directory for example code on how to call various REFPROP functions.
+   2. As part of the build process, this will download the entire REFPROP-wrappers repository and will also copy the example `/src` and `/include` directories to the top-level directory.
+   3. **Note:** In the new top-level `/external` directory, only the files in `/refprop/wrappers/C_CPP` need to be kept if you are just using the C/C++ wrapper.
+9. Open the `main.cpp` file in the `/src` directory for example code on how to call various REFPROP functions.
 
 
 Alternative

--- a/wrappers/C_CPP/README.md
+++ b/wrappers/C_CPP/README.md
@@ -1,18 +1,39 @@
 # REFPROP wrapper for C/C++
 
-Brought to you by Ian Bell, NIST, 2016
-
-Help!
------
-
-Please file an issue at https://github.com/usnistgov/REFPROP-issues and we will get back to you as quickly as possible.  Please don't email NIST staff directly, the only exception being if you have proprietary code that cannot be shared publicly.
-
 Installation
 ------------
+**NOTE**: for Linux and macOS, you must compile REFPROP yourself, see: [REFPROP-cmake](https://github.com/usnistgov/REFPROP-cmake)
 
-Follow the conventional installation instructions for REFPROP.  If you need to compile REFPROP yourself, see: [REFPROP-cmake](https://github.com/usnistgov/REFPROP-cmake)
+1. Follow the conventional installation instructions for REFPROP.
+2. For Linux and macOS, compile REFPROP via [REFPROP-cmake](https://github.com/usnistgov/REFPROP-cmake).
+3. Ensure that the system environment variable `RPprefix` is set to the location of the REFPROP installation (e.g., `C:\Program Files (x86)\REFPROP`).
+4. Install CMake, version 3.26 or newer. (https://cmake.org/download/).
+5. Install Git, version 2.0 or newer. (https://git-scm.com/downloads).
+6. For Windows, install the Microsoft Visual C++ compiler (MSVC). <br>(**Note:** This compiler is included with the Visual Studio IDE and this step can be skipped if that is already installed.)
+   1. Go to the Visual Studio download page (https://visualstudio.microsoft.com/downloads/).
+   2. Under "Tools for Visual Studio", download "Build Tools for Visual Studio 20XX".
+   3. Launch the installer and select the "C++ build tools" workload, ensuring that the MSVC compiler, Windows SDK and C++ Standard Library are included.
+   4. Complete the installation.
+7. Download the top-level `CMakeLists.txt` file into a directory that will be used for building the wrapper and associated code.
+8. Run CMake from this directory to generate the build files.
+   1. For Visual Studio on Windows, this can be accomplished by creating and running the following batch file (e.g., `build.bat`).
+      ```
+      rmdir /Q/S build
+      mkdir build
+      cd build
+   
+      cmake -G "Visual Studio 17 2022" -DCMAKE_CONFIGURATION_TYPES="Debug;Release" ..
+   
+      pause
+      ```
+   2. This will download the files in `/refprop` as part of its build process.
+9. Open the `main.cpp` file in the `src` directory for example code on how to call various REFPROP functions.
 
-Use
+
+Alternative
 ---
+REFPROP can also be called using the header defining the library at: [REFPROP-headers](https://github.com/CoolProp/REFPROP-headers). This header includes functions for runtime loading of the DLL (shared library). Present there are also examples of how to use it and a CMake-based build system. This is an older approach that is not recommended for new projects.
 
-Your best bet for calling REFPROP from C/C++ is to use the header defining the library and how to hook the library hosted at: [REFPROP-headers](https://github.com/CoolProp/REFPROP-headers) .  This header includes functions for runtime loading of the DLL (shared library), and some examples of how to use it, and integration with CMake.
+Help
+-----
+Please file an issue at https://github.com/usnistgov/REFPROP-issues and we will get back to you as quickly as possible. Please don't email NIST staff directly, the only exception being if you have proprietary code that cannot be shared publicly.

--- a/wrappers/C_CPP/README.md
+++ b/wrappers/C_CPP/README.md
@@ -15,7 +15,8 @@ Installation
    3. Launch the installer and select the "C++ build tools" workload, ensuring that the MSVC compiler, Windows SDK and C++ Standard Library are included.
    4. Complete the installation.
 7. Download the top-level `CMakeLists.txt` file into a directory that will be used for building the wrapper and associated code.
-8. Run CMake from this directory to generate the build files.
+8. Download the example code from the `/src` and `/include` directories into the same local directories.
+9. Run CMake from this directory to generate the build files.
    1. For Visual Studio on Windows, this can be accomplished by creating and running the following batch file (e.g., `build.bat`).
       ```
       rmdir /Q/S build
@@ -27,7 +28,7 @@ Installation
       pause
       ```
    2. This will download the files in `/refprop` as part of its build process.
-9. Open the `main.cpp` file in the `src` directory for example code on how to call various REFPROP functions.
+10. Open the `main.cpp` file in the `/src` directory for example code on how to call various REFPROP functions.
 
 
 Alternative

--- a/wrappers/C_CPP/include/MyProject/test_utils.h
+++ b/wrappers/C_CPP/include/MyProject/test_utils.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <iostream>
+#include <cmath>
+
+/// These are macros created with the same signature as those in GoogleTest
+
+#define EXPECT_EQ(expected, actual) \
+  do { \
+    if ((expected) != (actual)) { \
+      std::cout << "Error: Expected " << (expected) << " to be equal to " << (actual) << " in " << __func__ << std::endl; \
+    } \
+  } while (0)
+
+#define EXPECT_NE(expected, actual) \
+  do { \
+    if ((expected) == (actual)) { \
+      std::cout << "Error: Expected " << (expected) << " to not be equal to " << (actual) << " in " << __func__ << std::endl; \
+    } \
+  } while (0)
+
+#define EXPECT_NEAR(expected, actual, abs_tol) \
+  do { \
+    if (std::abs((expected) - (actual)) > (abs_tol)) { \
+      std::cout << "Error: Expected " << (expected) << " to be within " << (abs_tol) << " of " << (actual) << " in " << __func__ << std::endl; \
+    } \
+  } while (0)
+
+#define EXPECT_NEAR_REL(expected, actual, rel_tol) \
+  EXPECT_NEAR(expected, actual, std::abs((expected) * (rel_tol)))

--- a/wrappers/C_CPP/refprop/CMakeLists.txt
+++ b/wrappers/C_CPP/refprop/CMakeLists.txt
@@ -1,0 +1,86 @@
+﻿cmake_minimum_required(VERSION 3.26)
+project(Refprop)
+
+# Set C++ standard version
+set(CMAKE_CXX_STANDARD 11)
+set(MAKE_CXX_STANDARD_REQUIRED ON)
+
+# ---- Add manyso ----------------
+message(STATUS "Adding manyso")
+set(MANYSO_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/manyso")
+include(FetchContent)
+if(EXISTS ${MANYSO_SOURCE_DIR})
+  # Use previously downloaded repo
+  FetchContent_Declare(
+    manyso
+	SOURCE_DIR ${MANYSO_SOURCE_DIR}
+  )
+else()
+  # Download repo
+  message(STATUS "Fetching manyso library")
+  FetchContent_Declare(
+    manyso
+    GIT_REPOSITORY https://github.com/usnistgov/manyso
+    GIT_TAG 8ad7331582143923ee2c04d522d3bc0c1005794d
+    GIT_SHALLOW TRUE                    # TRUE=retrieve only latest commit in tree
+    SOURCE_DIR ${MANYSO_SOURCE_DIR}     # local destination turned source directory
+  )
+endif()
+FetchContent_Populate(manyso)
+include_directories("${MANYSO_SOURCE_DIR}/include")
+
+# ---- Add MemoryModule ----------------
+set(MEMORYMODULE_DIR "${MANYSO_SOURCE_DIR}/externals/MemoryModule")
+add_library (MemoryModule STATIC
+  ${MEMORYMODULE_DIR}/MemoryModule.c
+  ${MEMORYMODULE_DIR}/MemoryModule.h
+)
+set_target_properties(MemoryModule PROPERTIES LINKER_LANGUAGE C)
+target_include_directories(MemoryModule PUBLIC
+  ${MEMORYMODULE_DIR}
+  "${MANYSO_SOURCE_DIR}/include"
+)
+target_compile_options(MemoryModule PUBLIC
+  $<$<CONFIG:Debug>:/MDd>
+  $<$<CONFIG:Release>:/MD>
+)
+
+# ---- Add REFPROP v10 ----------------
+message(STATUS "Adding REFPROP v10")
+string(REPLACE "\\" "/" REFPROP10_DIR $ENV{RPprefix})   # get REFPROP path but replace any backslashes with forward slashes
+set(REFPROP10_DLL "REFPRP64.DLL")
+set(REFPROP10_LIB "REFPRP64.LIB")
+add_library(refprop10_lib SHARED IMPORTED GLOBAL)
+set_target_properties(refprop10_lib PROPERTIES
+  IMPORTED_LOCATION_DEBUG ${REFPROP10_DIR}/${REFPROP10_DLL}
+  IMPORTED_LOCATION_RELEASE ${REFPROP10_DIR}/${REFPROP10_DLL}
+  IMPORTED_IMPLIB_DEBUG ${REFPROP10_DIR}/${REFPROP10_LIB}
+  IMPORTED_IMPLIB_RELEASE ${REFPROP10_DIR}/${REFPROP10_LIB}
+)
+add_compile_definitions(REFPROP10_PATH="${REFPROP10_DIR}/${REFPROP10_DLL}")	# pass value to source code
+
+# Specify header and source directories
+set(HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+# Specify library
+file(GLOB_RECURSE HEADER_FILES
+  "${HEADER_DIR}/*.h"
+  "${HEADER_DIR}/*.hpp")
+file(GLOB SOURCE_FILES
+  "${SOURCE_DIR}/*.cpp")
+add_library(refprop ${HEADER_FILES} ${SOURCE_FILES})
+
+# Add subdirectories
+target_include_directories(refprop PUBLIC
+  ${HEADER_DIR}
+  ${HEADER_DIR}/${PROJECT_NAME}
+)
+
+# Pass root directory to C++ source code
+add_compile_definitions(PROJECT_DIR="${CMAKE_SOURCE_DIR}")
+
+target_link_libraries(refprop PUBLIC
+  MemoryModule
+  refprop10_lib
+)

--- a/wrappers/C_CPP/refprop/CMakeLists.txt
+++ b/wrappers/C_CPP/refprop/CMakeLists.txt
@@ -50,13 +50,6 @@ message(STATUS "Adding REFPROP v10")
 string(REPLACE "\\" "/" REFPROP10_DIR $ENV{RPprefix})   # get REFPROP path but replace any backslashes with forward slashes
 set(REFPROP10_DLL "REFPRP64.DLL")
 set(REFPROP10_LIB "REFPRP64.LIB")
-add_library(refprop10_lib SHARED IMPORTED GLOBAL)
-set_target_properties(refprop10_lib PROPERTIES
-  IMPORTED_LOCATION_DEBUG ${REFPROP10_DIR}/${REFPROP10_DLL}
-  IMPORTED_LOCATION_RELEASE ${REFPROP10_DIR}/${REFPROP10_DLL}
-  IMPORTED_IMPLIB_DEBUG ${REFPROP10_DIR}/${REFPROP10_LIB}
-  IMPORTED_IMPLIB_RELEASE ${REFPROP10_DIR}/${REFPROP10_LIB}
-)
 add_compile_definitions(REFPROP10_PATH="${REFPROP10_DIR}/${REFPROP10_DLL}")	# pass value to source code
 
 # Specify header and source directories
@@ -82,5 +75,4 @@ add_compile_definitions(PROJECT_DIR="${CMAKE_SOURCE_DIR}")
 
 target_link_libraries(refprop PUBLIC
   MemoryModule
-  refprop10_lib
 )

--- a/wrappers/C_CPP/refprop/CMakeLists.txt
+++ b/wrappers/C_CPP/refprop/CMakeLists.txt
@@ -46,12 +46,6 @@ target_compile_options(MemoryModule PUBLIC
 )
 
 # ---- Add REFPROP v10 ----------------
-message(STATUS "Adding REFPROP v10")
-string(REPLACE "\\" "/" REFPROP10_DIR $ENV{RPprefix})   # get REFPROP path but replace any backslashes with forward slashes
-set(REFPROP10_DLL "REFPRP64.DLL")
-set(REFPROP10_LIB "REFPRP64.LIB")
-add_compile_definitions(REFPROP10_PATH="${REFPROP10_DIR}/${REFPROP10_DLL}")	# pass value to source code
-
 # Specify header and source directories
 set(HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
@@ -70,9 +64,7 @@ target_include_directories(refprop PUBLIC
   ${HEADER_DIR}/${PROJECT_NAME}
 )
 
-# Pass root directory to C++ source code
-add_compile_definitions(PROJECT_DIR="${CMAKE_SOURCE_DIR}")
-
+# Link libraries
 target_link_libraries(refprop PUBLIC
   MemoryModule
 )

--- a/wrappers/C_CPP/refprop/include/Refprop/REFPROP_lib.h
+++ b/wrappers/C_CPP/refprop/include/Refprop/REFPROP_lib.h
@@ -1,0 +1,854 @@
+
+#ifndef REFPROP_LIB_H
+#define REFPROP_LIB_H
+
+// The idea here is to have a common header for Windows 
+// and Linux systems. The Windows branch should cover the
+// functions provided by the .dll and the Linux part covers
+// the compiled .so file. Name changes caused by gfortran 
+// are respected and should be accounted for. 
+
+// Get the platform identifiers, some overlap with "PlatformDetermination.h" from CoolProp's main repo 
+// See also http://stackoverflow.com/questions/5919996/how-to-detect-reliably-mac-os-x-ios-linux-windows-in-c-preprocessor
+#if defined(_WIN32) || defined(__WIN32__) || defined(_WIN64) || defined(__WIN64__)
+#    define __RPISWINDOWS__
+#elif defined(__APPLE__)
+#    define __RPISAPPLE__
+#elif defined(__linux) || defined(__unix) || defined(__posix)
+#    define __RPISLINUX__
+#elif defined(__powerpc__)
+#    define __RPISPOWERPC__
+#else
+#    pragma error
+#endif
+
+// Define compiler specific calling conventions
+// for the shared library.
+#if defined(__RPISWINDOWS__)
+#    define RPCALLCONV __stdcall
+#else
+#    define RPCALLCONV
+#endif
+
+#if defined(__cplusplus)
+// Function prototypes that are implemented below when REFPROP_IMPLEMENTATION macro is defined
+// before this header is included.  REFPROP_IMPLEMENTATION shall be implemented in ONLY ONE
+// compilation unit
+#include <string>
+bool load_REFPROP(std::string &err, const std::string &shared_library_path = "", const std::string &shared_library_name = "");
+bool unload_REFPROP(std::string &err);
+std::size_t REFPROP_address();
+#endif
+
+// ******************************************
+// ******************************************
+// Headers (platform specific and otherwise)
+// ******************************************
+// ******************************************
+
+#ifdef REFPROP_IMPLEMENTATION
+
+    #ifndef __cplusplus
+    #error REFPROP_IMPLEMENTATION can only be used in C++
+    #endif
+
+    #if defined(__RPISPOWERPC__)
+        #include <cstring>
+    #elif defined(__RPISLINUX__) || defined(__RPISAPPLE__)
+        #include <cstring>
+        #include <dlfcn.h>
+    #elif defined(__RPISWINDOWS__)
+
+        #if defined(_MSC_VER)
+        #ifndef _CRT_SECURE_NO_WARNINGS
+        #define _CRT_SECURE_NO_WARNINGS
+        #endif
+        #endif
+
+        #ifndef NOMINMAX
+            #define NOMINMAX
+            #include <windows.h>
+            #undef NOMINMAX
+        #else 
+            #include <windows.h>
+        #endif
+
+        #if defined(_MSC_VER)
+        #undef _CRT_SECURE_NO_WARNINGS
+        #endif
+
+        
+    #else
+        #pragma error
+    #endif
+
+    #include <sstream>
+    #include <string>
+    #include <algorithm>
+
+#endif
+
+/* See http://stackoverflow.com/a/148610
+ * See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511
+ * This will be used to generate function names, pointers, etc. below
+ */
+#define LIST_OF_REFPROP_FUNCTION_NAMES \
+    X(ABFL1dll) \
+    X(ABFL2dll) \
+    X(ABFLSHdll) \
+    X(ABFLASHdll) \
+    X(AGdll) \
+    X(ALLPROPS0dll) \
+    X(ALLPROPS1dll) \
+    X(ALLPROPS20dll) \
+    X(ALLPROPSdll) \
+    X(B12dll) \
+    X(BLCRVdll) \
+    X(CCRITdll) \
+    X(CHEMPOTdll) \
+    X(CP0dll) \
+    X(CRITPdll) \
+    X(CRTPNTdll) \
+    X(CSATKdll) \
+    X(CSTARdll) \
+    X(CV2PKdll) \
+    X(CVCPKdll) \
+    X(CVCPdll) \
+    X(DBDTdll) \
+    X(DBFL1dll) \
+    X(DBFL2dll) \
+    X(DDDPdll) \
+    X(DDDTdll) \
+    X(DEFL1dll) \
+    X(DEFLSHdll) \
+    X(DERVPVTdll) \
+    X(DHD1dll) \
+    X(DHFL1dll) \
+    X(DHFLSHdll) \
+    X(DIELECdll) \
+    X(DLSATKdll) \
+    X(DPDD2dll) \
+    X(DPDDdll) \
+    X(DPDTdll) \
+    X(DPTSATKdll) \
+    X(DQFL2dll) \
+    X(DSD1dll) \
+    X(DSFL1dll) \
+    X(DSFLSHdll) \
+    X(DVSATKdll) \
+    X(ENTHALdll) \
+    X(ENTROdll) \
+    X(ERRMSGdll) \
+    X(ESFLSHdll) \
+    X(EXCESSdll) \
+    X(FGCTY2dll) \
+    X(FGCTYdll) \
+    X(FLAGSdll) \
+    X(FPVdll) \
+    X(FUGCOFdll) \
+    X(GERG04dll) \
+    X(GERG08dll) \
+    X(GETENUMdll) \
+    X(GETFIJdll) \
+    X(GETKTVdll) \
+    X(GETMODdll) \
+    X(GETREFDIRdll) \
+    X(GIBBSdll) \
+    X(HEATFRMdll) \
+    X(HEATdll) \
+    X(HMXORDERdll) \
+    X(HSFL1dll) \
+    X(HSFLSHdll) \
+    X(IDCRVdll) \
+    X(INFOdll) \
+    X(JICRVdll) \
+    X(JTCRVdll) \
+    X(LIMITKdll) \
+    X(LIMITSdll) \
+    X(LIMITXdll) \
+    X(LIQSPNDLdll) \
+    X(MASSFLUXdll) \
+    X(MAXPdll) \
+    X(MAXTdll) \
+    X(MELTKdll) \
+    X(MELTPdll) \
+    X(MELTTdll) \
+    X(MLTH2Odll) \
+    X(NAMEdll) \
+    X(PASSCMNdll) \
+    X(PDFL1dll) \
+    X(PDFLSHdll) \
+    X(PEFL1dll) \
+    X(PEFLSHdll) \
+    X(PHFL1dll) \
+    X(PHFLSHdll) \
+    X(PHI0dll) \
+    X(PHIDERVdll) \
+    X(PHIHMXdll) \
+    X(PHIKdll) \
+    X(PHIMIXdll) \
+    X(PHIXdll) \
+    X(PQFLSHdll) \
+    X(PREOSdll) \
+    X(PRESSdll) \
+    X(PSATKdll) \
+    X(PSFL1dll) \
+    X(PSFLSHdll) \
+    X(PUREFLDdll) \
+    X(QMASSdll) \
+    X(QMOLEdll) \
+    X(RDXHMXdll) \
+    X(REDXdll) \
+    X(REFPROP1dll) \
+    X(REFPROP2dll) \
+    X(REFPROPdll) \
+    X(RESIDUALdll) \
+    X(RIEMdll) \
+    X(RMIX2dll) \
+    X(RPVersion) \
+    X(SATDdll) \
+    X(SATESTdll) \
+    X(SATEdll) \
+    X(SATGUESSdll) \
+    X(SATGVdll) \
+    X(SATHdll) \
+    X(SATPESTdll) \
+    X(SATPdll) \
+    X(SATSPLNdll) \
+    X(SATSdll) \
+    X(SATTESTdll) \
+    X(SATTPdll) \
+    X(SATTdll) \
+    X(SETAGAdll) \
+    X(SETFLUIDSdll) \
+    X(SETKTVdll) \
+    X(SETMIXTUREdll) \
+    X(SETMIXdll) \
+    X(SETMODdll) \
+    X(SETNCdll) \
+    X(SETPATHdll) \
+    X(SETREFDIRdll) \
+    X(SETREFdll) \
+    X(SETUPdll) \
+    X(SPLNROOTdll) \
+    X(SPLNVALdll) \
+    X(STNdll) \
+    X(SUBLPdll) \
+    X(SUBLTdll) \
+    X(SURFTdll) \
+    X(SURTENdll) \
+    X(TDFLSHdll) \
+    X(TEFL1dll) \
+    X(TEFLSHdll) \
+    X(THERM0dll) \
+    X(THERM2dll) \
+    X(THERM3dll) \
+    X(THERMdll) \
+    X(THFL1dll) \
+    X(THFLSHdll) \
+    X(TPFL2dll) \
+    X(TPFLSHdll) \
+    X(TPRHOPRdll) \
+    X(TPRHOdll) \
+    X(TQFLSHdll) \
+    X(TRNPRPdll) \
+    X(TSATDdll) \
+    X(TSATPdll) \
+    X(TSFL1dll) \
+    X(TSFLSHdll) \
+    X(UNSETAGAdll) \
+    X(VAPSPNDLdll) \
+    X(VIRBAdll) \
+    X(VIRBCDdll) \
+    X(VIRBCD12dll) \
+    X(VIRBdll) \
+    X(VIRCAdll) \
+    X(VIRCdll) \
+    X(VIRTAUdll) \
+    X(WMOLIdll) \
+    X(WMOLdll) \
+    X(XMASSdll) \
+    X(XMOLEdll)
+
+// By default the functions are defined to be static and not visible to other compilation units
+// You could for instance set this macro to "" which would make the symbols available
+#ifndef REFPROP_FUNCTION_MODIFIER
+#define REFPROP_FUNCTION_MODIFIER static
+#endif
+
+// define new macros for function names
+// http://stackoverflow.com/questions/195975/how-to-make-a-char-string-from-a-c-macros-value
+#define STR_VALUE(arg)      #arg
+#define FUNCTION_NAME(name) STR_VALUE(name)
+#define STRINGIFY(name) STR_VALUE(name)
+
+// In C++, references are done using double &, and in C, using double *
+// C++ can use C-style references or pointers
+// C can only use pointers
+#if !defined(__cplusplus) || defined(REFPROP_CSTYLE_REFERENCES)
+    // For C compilation, must do double *, int * since C doesn't understand double &, SIZE_T &
+    #define DOUBLE_REF double *
+    #define INT_REF int *
+#else
+    #define DOUBLE_REF double &
+    #define INT_REF int &
+#endif
+
+// We must determine the size of std::size_t because that is the variable type that should be used to define the string lengths
+// See also https://software.intel.com/en-us/articles/passing-character-string-in-intel-64-mixed-fortranc-project
+#if !defined(__cplusplus)
+    #if !defined(SIZE_T_TYPE)
+    #error The preprocessor macro SIZE_T_TYPE must be defined and give the unsigned integer variable type that is the same size (in bytes) as std::size_t
+    #endif
+    #define RP_SIZE_T SIZE_T_TYPE
+#else 
+    #include <cstdio>
+    #define RP_SIZE_T std::size_t
+#endif
+
+// Some string length constants for REFPROP...
+const static RP_SIZE_T refpropcharlength = 255;
+const static RP_SIZE_T filepathlength = 255;
+const static RP_SIZE_T lengthofreference = 3;
+const static RP_SIZE_T errormessagelength = 255;
+const static RP_SIZE_T ncmax = 20;
+const static RP_SIZE_T numparams = 72;
+const static RP_SIZE_T maxcoefs = 50;
+const static RP_SIZE_T componentstringlength = 10000; // Length of component_string (see PASS_FTN.for from REFPROP)
+const static RP_SIZE_T versionstringlength = 1000; 
+
+#ifdef REFPROP_LIB_NAMESPACE
+namespace REFPROP_LIB_NAMESPACE {
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    // For C calling conventions, replaced all "double &" with "double *", and "int &" with "int *"
+    
+    #define ABFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,char *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define ABFL2dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,INT_REF,char *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define ABFLSHdll_ARGS char *,DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define ABFLASHdll_ARGS char *,DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define AGdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF
+    #define ALLPROPS0dll_ARGS INT_REF,int *,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define ALLPROPS1dll_ARGS char *,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define ALLPROPS20dll_ARGS char *,INT_REF,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,char *,int *,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define ALLPROPSdll_ARGS char *,INT_REF,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,char *,int *,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define B12dll_ARGS DOUBLE_REF,double *,DOUBLE_REF
+    #define BLCRVdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define CCRITdll_ARGS DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define CHEMPOTdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define CP0dll_ARGS DOUBLE_REF,double *,DOUBLE_REF
+    #define CRITPdll_ARGS double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define CRTPNTdll_ARGS double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define CSATKdll_ARGS INT_REF,DOUBLE_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define CSTARdll_ARGS DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define CV2PKdll_ARGS INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define CVCPKdll_ARGS INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define CVCPdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF
+    #define DBDTdll_ARGS DOUBLE_REF,double *,DOUBLE_REF
+    #define DBFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,char *,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define DBFL2dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,char *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define DDDPdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define DDDTdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define DEFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define DEFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define DERVPVTdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define DHD1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define DHFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define DHFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define DIELECdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define DLSATKdll_ARGS INT_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define DPDD2dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define DPDDdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define DPDTdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define DPTSATKdll_ARGS INT_REF,DOUBLE_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define DQFL2dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define DSD1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define DSFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define DSFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define DVSATKdll_ARGS INT_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define ENTHALdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define ENTROdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define ERRMSGdll_ARGS INT_REF,char *,RP_SIZE_T
+    #define ESFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define EXCESSdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define FGCTY2dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define FGCTYdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,double *
+    #define FLAGSdll_ARGS char *,INT_REF,INT_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define FPVdll_ARGS DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define FUGCOFdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define GERG04dll_ARGS INT_REF,INT_REF,INT_REF,char *,RP_SIZE_T
+    #define GERG08dll_ARGS INT_REF,INT_REF,INT_REF,char *,RP_SIZE_T
+    #define GETENUMdll_ARGS INT_REF,char *,INT_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define GETFIJdll_ARGS char *,double *,char *,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define GETKTVdll_ARGS INT_REF,INT_REF,char *,double *,char *,char *,char *,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define GETMODdll_ARGS INT_REF,char *,char *,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define GETREFDIRdll_ARGS char *,RP_SIZE_T
+    #define GIBBSdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF
+    #define HEATFRMdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define HEATdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define HMXORDERdll_ARGS INT_REF,INT_REF,char *,char *,INT_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define HSFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define HSFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define IDCRVdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define INFOdll_ARGS INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define JICRVdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define JTCRVdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define LIMITKdll_ARGS char *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define LIMITSdll_ARGS char *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,RP_SIZE_T
+    #define LIMITXdll_ARGS char *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define LIQSPNDLdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define MASSFLUXdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define MAXPdll_ARGS double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define MAXTdll_ARGS double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define MELTKdll_ARGS INT_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define MELTPdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define MELTTdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define MLTH2Odll_ARGS DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define NAMEdll_ARGS INT_REF,char *,char *,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define PASSCMNdll_ARGS char *,INT_REF,INT_REF,INT_REF,char *,INT_REF,DOUBLE_REF,double *,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define PDFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PDFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PEFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PEFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PHFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PHFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PHI0dll_ARGS INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define PHIDERVdll_ARGS INT_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define PHIHMXdll_ARGS INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define PHIKdll_ARGS INT_REF,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define PHIMIXdll_ARGS INT_REF,INT_REF,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define PHIXdll_ARGS INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define PQFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PREOSdll_ARGS INT_REF
+    #define PRESSdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define PSATKdll_ARGS INT_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PSFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PSFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define PUREFLDdll_ARGS INT_REF
+    #define QMASSdll_ARGS DOUBLE_REF,double *,double *,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define QMOLEdll_ARGS DOUBLE_REF,double *,double *,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define RDXHMXdll_ARGS INT_REF,INT_REF,INT_REF,double *,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define REDXdll_ARGS double *,DOUBLE_REF,DOUBLE_REF
+    #define REFPROP1dll_ARGS char *,char *,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define REFPROP2dll_ARGS char *,char *,char *,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define REFPROPdll_ARGS char *,char *,char *,INT_REF,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,char *,INT_REF,double *,double *,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define RESIDUALdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define RIEMdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF
+    #define RMIX2dll_ARGS double *,DOUBLE_REF
+    #define RPVersion_ARGS char *,RP_SIZE_T
+    #define SATDdll_ARGS DOUBLE_REF,double *,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define SATESTdll_ARGS INT_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define SATEdll_ARGS DOUBLE_REF,double *,INT_REF,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define SATGUESSdll_ARGS INT_REF,INT_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,INT_REF,char *,RP_SIZE_T
+    #define SATGVdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,INT_REF,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define SATHdll_ARGS DOUBLE_REF,double *,INT_REF,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define SATPESTdll_ARGS DOUBLE_REF,double *,INT_REF,DOUBLE_REF,double *,INT_REF,char *,RP_SIZE_T
+    #define SATPdll_ARGS DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define SATSPLNdll_ARGS double *,INT_REF,char *,RP_SIZE_T
+    #define SATSdll_ARGS DOUBLE_REF,double *,INT_REF,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define SATTESTdll_ARGS DOUBLE_REF,double *,INT_REF,DOUBLE_REF,double *,INT_REF,char *,RP_SIZE_T
+    #define SATTPdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define SATTdll_ARGS DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define SETAGAdll_ARGS INT_REF,char *,RP_SIZE_T
+    #define SETFLUIDSdll_ARGS char *,INT_REF,RP_SIZE_T
+    #define SETKTVdll_ARGS INT_REF,INT_REF,char *,double *,char *,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define SETMIXTUREdll_ARGS char *,double *,INT_REF,RP_SIZE_T
+    #define SETMIXdll_ARGS char *,char *,char *,INT_REF,char *,double *,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define SETMODdll_ARGS INT_REF,char *,char *,char *,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define SETNCdll_ARGS INT_REF
+    #define SETPATHdll_ARGS char *,RP_SIZE_T
+    #define SETREFDIRdll_ARGS char *,RP_SIZE_T
+    #define SETREFdll_ARGS char *,INT_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T,RP_SIZE_T
+    #define SETUPdll_ARGS INT_REF,char *,char *,char *,INT_REF,char *,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T,RP_SIZE_T
+    #define SPLNROOTdll_ARGS INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define SPLNVALdll_ARGS INT_REF,INT_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define STNdll_ARGS DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define SUBLPdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define SUBLTdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define SURFTdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define SURTENdll_ARGS DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TDFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TEFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TEFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define THERM0dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define THERM2dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define THERM3dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define THERMdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define THFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define THFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TPFL2dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TPFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TPRHOPRdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF
+    #define TPRHOdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,INT_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TQFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TRNPRPdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TSATDdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TSATPdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TSFL1dll_ARGS DOUBLE_REF,DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define TSFLSHdll_ARGS DOUBLE_REF,DOUBLE_REF,double *,INT_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,double *,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define UNSETAGAdll_ARGS 
+    #define VAPSPNDLdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,INT_REF,char *,RP_SIZE_T
+    #define VIRBAdll_ARGS DOUBLE_REF,double *,DOUBLE_REF
+    #define VIRBCD12dll_ARGS DOUBLE_REF,double *,INT_REF,double *,double *,double *,double *
+    #define VIRBCDdll_ARGS DOUBLE_REF,double *,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF,DOUBLE_REF
+    #define VIRBdll_ARGS DOUBLE_REF,double *,DOUBLE_REF
+    #define VIRCAdll_ARGS DOUBLE_REF,double *,DOUBLE_REF
+    #define VIRCdll_ARGS DOUBLE_REF,double *,DOUBLE_REF
+    #define VIRTAUdll_ARGS DOUBLE_REF,double *,INT_REF,double *,double *,double *,double *,INT_REF,char *,RP_SIZE_T
+    #define WMOLIdll_ARGS INT_REF,DOUBLE_REF
+    #define WMOLdll_ARGS double *,DOUBLE_REF
+    #define XMASSdll_ARGS double *,double *,DOUBLE_REF
+    #define XMOLEdll_ARGS double *,double *,DOUBLE_REF
+
+#if !defined(REFPROP_ONLY_MACROS)
+
+    #if !defined(REFPROP_PROTOTYPES)
+    
+        // ***MAGIC WARNING**!! X Macros in use
+        // See http://stackoverflow.com/a/148610
+        // See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511
+        
+        // Further information here:
+        // http://www.gershnik.com/tips/cpp.asp
+    
+        // Define type names for each function
+        // Each will look something like: typedef void (RPCALLCONV ACTVYdll_TYPE)(ACTVYdll_ARGS);
+        // 
+        // The ## are needed to escape the _ character in the variable names
+        // 
+        #define X(name) typedef void (RPCALLCONV name ## _TYPE)(name ## _ARGS);
+            LIST_OF_REFPROP_FUNCTION_NAMES
+        #undef X
+        
+        // Define explicit function pointers for each function
+        // Each will look something like: typedef RPVersion_TYPE * RPVersion_POINTER;
+        // 
+        // The ## are needed to escape the _ character in the variable names
+        // 
+        #define X(name) typedef name ## _TYPE * name ## _POINTER;
+            LIST_OF_REFPROP_FUNCTION_NAMES
+        #undef X
+        
+        // Define functions as pointers
+        // Each will look something like: SETPATHdll_POINTER SETPATHdll;
+        //
+        #ifdef REFPROP_IMPLEMENTATION
+            // Here we want to define them to be used in this file only
+            // since we are adding all the accessor functions
+            // Defined as static (by default, but see above) to ensure they are only in this file
+            #define X(name) REFPROP_FUNCTION_MODIFIER name ## _POINTER name;
+                LIST_OF_REFPROP_FUNCTION_NAMES
+            #undef X
+        #else
+            // Otherwise, for other files adding the header, define the pointers to be extern, 
+            // so they can see the pointers in a read-only fashion
+            #define X(name)  extern name ## _POINTER name;
+                LIST_OF_REFPROP_FUNCTION_NAMES
+            #undef X
+        #endif
+    #else
+        // Otherwise this header becomes just a set of prototypes for the functions
+        // defining the input parameters
+        //
+        // The ## are needed to escape the _ character in the macro name in the intermediate expansion
+        // 
+        #define X(name) extern void name(name ## _ARGS);
+            LIST_OF_REFPROP_FUNCTION_NAMES
+        #undef X
+    #endif
+
+#endif  // (REFPROP_ONLY_MACROS)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+//******************************************************************************
+//******************************************************************************
+//*********************  REFPROP IMPLEMENTATION  *******************************
+//******************************************************************************
+//******************************************************************************
+
+// Define this preprocessor flag to also define the function prototypes and connect function pointers
+// N.B. Define this macro in only one location
+// N.B. This is C++-only, though with some work it could be made C compatible
+#ifdef REFPROP_IMPLEMENTATION
+
+    #if defined(__powerpc__)
+        static void *RefpropdllInstance=NULL;
+    #elif defined(__RPISLINUX__) || defined(__RPISAPPLE__)
+        static void *RefpropdllInstance=NULL;
+    #elif defined(__RPISWINDOWS__)
+        static HINSTANCE RefpropdllInstance=NULL;
+    #else
+        #pragma error
+    #endif
+
+    // Define the default library names
+    const static std::string shared_lib_WIN64 = "REFPRP64.dll";
+    const static std::string shared_lib_WIN32 = "REFPROP.dll";
+    const static std::string shared_lib_LINUX = "librefprop.so";
+    const static std::string shared_lib_APPLE = "librefprop.dylib";
+
+    static std::string RPVersion_loaded = "";
+    static std::string RPPath_loaded = "";
+
+    enum DLLNameManglingStyle{ NO_NAME_MANGLING = 0, LOWERCASE_NAME_MANGLING, LOWERCASE_AND_UNDERSCORE_NAME_MANGLING };
+
+    const std::string& get_shared_lib()
+    {
+#if defined(__RPISWINDOWS__)
+    #if defined(_WIN64) || defined(__WIN64__)
+        return shared_lib_WIN64;
+    #elif defined(_WIN32) || defined(__WIN32__)
+        return shared_lib_WIN32;
+    #else
+        if (sizeof(void*) == 8) { // Assume 64bit
+            return shared_lib_WIN64;
+        } else {
+            return shared_lib_WIN32;
+        }
+    #endif  
+#elif defined(__RPISLINUX__)
+        return shared_lib_LINUX;
+#elif defined(__RPISAPPLE__)
+        return shared_lib_APPLE;
+#endif
+    }
+    
+    inline std::string RPlower(std::string str)
+    {
+        std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+        return str;
+    }
+
+    void *getFunctionPointer(const char *name, DLLNameManglingStyle mangling_style = NO_NAME_MANGLING)
+    {
+        std::string function_name;
+        switch(mangling_style)
+        {
+            case NO_NAME_MANGLING:
+                function_name = name; break;
+            case LOWERCASE_NAME_MANGLING:
+                function_name = RPlower(name); break;
+            case LOWERCASE_AND_UNDERSCORE_NAME_MANGLING:
+                function_name = RPlower(name) + "_"; break;
+        }
+        #if defined(__RPISWINDOWS__)
+            return (void *) GetProcAddress(RefpropdllInstance, function_name.c_str());
+        #elif defined(__RPISLINUX__)
+            return dlsym(RefpropdllInstance, function_name.c_str());
+        #elif defined(__RPISAPPLE__)
+            return dlsym(RefpropdllInstance, function_name.c_str());
+        #else
+            return NULL;
+        #endif
+    }
+
+    /**
+     * @brief Set the function pointers in the DLL/SO
+     */
+    bool setFunctionPointers(std::string &err)
+    {
+        if (RefpropdllInstance==NULL)
+        { 
+            err = "REFPROP is not loaded, make sure you call this function after loading the library using load_REFPROP.";
+            return false;
+        }
+        /* First determine the type of name mangling in use.
+         * A) RPVersion -> RPVersion
+         * B) RPVersion -> rpversion
+         * C) RPVersion -> rpversion_
+         */
+        DLLNameManglingStyle mangling_style = NO_NAME_MANGLING; // defaults to no mangling
+
+        SETUPdll = (SETUPdll_POINTER) getFunctionPointer("SETUPdll"); // try NO_NAME_MANGLING
+        if (SETUPdll == NULL) 
+        { 
+            SETUPdll = (SETUPdll_POINTER) getFunctionPointer("setupdll"); // try LOWERCASE_NAME_MANGLING
+            if (SETUPdll == NULL) 
+            {
+                SETUPdll = (SETUPdll_POINTER) getFunctionPointer("setupdll_"); // try LOWERCASE_AND_UNDERSCORE_NAME_MANGLING
+                if (SETUPdll == NULL) 
+                {
+                    err = "Could not load the symbol SETUPdll or any of its mangled forms; REFPROP shared library broken.";
+                    return false;
+                } else {
+                    mangling_style = LOWERCASE_AND_UNDERSCORE_NAME_MANGLING;
+                }
+            } else {
+                mangling_style = LOWERCASE_NAME_MANGLING;
+            }
+        } else {
+            mangling_style = NO_NAME_MANGLING;
+        } 
+
+        /* Set the pointers, platform independent
+         *
+         * Example: RPVersion = (RPVersion_POINTER) getFunctionPointer(STRINGIFY(RPVersion));
+         *
+         * ***MAGIC WARNING**!! X Macros in use
+         * See http://stackoverflow.com/a/148610
+         * See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511
+         */
+        #define X(name)  name = (name ## _POINTER) getFunctionPointer(STRINGIFY(name), mangling_style);
+           LIST_OF_REFPROP_FUNCTION_NAMES
+        #undef X
+
+        return true;
+    }
+
+    // See http://stackoverflow.com/questions/874134/find-if-string-ends-with-another-string-in-c
+    inline bool RP_ends_with(const std::string & value, const std::string & ending) {
+        if (value.empty()) return false;
+        if (ending.empty()) return false;
+        if (ending.size() > value.size()) return false;
+        return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+    }
+
+    std::string RP_join_path(const std::string &one, const std::string &two) {
+        std::string result;
+        std::string separator;
+        #if defined(__RPISWINDOWS__)
+            separator = "\\";
+        #elif defined(__RPISLINUX__)
+            separator = "/";
+        #elif defined(__RPISAPPLE__)
+            separator = "/";
+        #endif
+        if (!RP_ends_with(one, separator) && !one.empty()) {
+            result = one + separator;
+        } else {
+            result = one;
+        }
+        result.append(two);
+        return result;
+    }
+
+    bool load_REFPROP(std::string &err, const std::string &shared_library_path, const std::string &shared_library_name)
+    {
+        // If REFPROP is not loaded
+        if (RefpropdllInstance == NULL)
+        {
+            // Load it
+            std::string msg;
+            std::string shared_lib;
+            if (shared_library_name.empty()) 
+            {
+                shared_lib = get_shared_lib();
+            } else {
+                shared_lib = shared_library_name;
+            }
+            #if defined(__RPISWINDOWS__)
+                // Load the DLL
+                TCHAR refpropdllstring[_MAX_PATH];
+                strcpy((char*)refpropdllstring, RP_join_path(shared_library_path, shared_lib).c_str());
+                RefpropdllInstance = LoadLibrary(refpropdllstring);
+                // Error handling
+                if (RefpropdllInstance == NULL)
+                {
+                    std::stringstream msg_stream;
+                    msg_stream << GetLastError(); // returns error
+                    msg = msg_stream.str();
+                } else {
+                    TCHAR dllPath[_MAX_PATH];
+                    HMODULE hModule;
+                    hModule = GetModuleHandle(refpropdllstring);
+                    GetModuleFileName(hModule, dllPath, _MAX_PATH);
+                    #ifndef UNICODE
+                        msg = dllPath;
+                    #else
+                        std::wstring wStr = dllPath;
+                        msg = std::string(wStr.begin(), wStr.end());
+                    #endif
+                    RPPath_loaded = msg;
+                }
+            #elif ( defined(__RPISLINUX__) || defined(__RPISAPPLE__) )
+                // Load library
+                RefpropdllInstance = dlopen (RP_join_path(shared_library_path, shared_lib).c_str(), RTLD_NOW); 
+                // Error handling
+                if (RefpropdllInstance == NULL) 
+                {
+                    const char *errstr = dlerror();
+                    if (errstr != NULL) 
+                    {
+                        msg = errstr;
+                    }
+                } else {
+                    RPPath_loaded = RP_join_path(shared_library_path, shared_lib);
+                }
+            #else
+                RefpropdllInstance = NULL;
+                RPPath_loaded = "";
+                msg = "Something is wrong with the platform definition, you should not end up here.";
+            #endif
+
+            if (RefpropdllInstance == NULL)
+            {
+                err = "Could not load REFPROP (" + shared_lib + ") due to: " + msg + ". ";
+                err.append("Make sure the library is in your system search path. ");
+                err.append("In case you run 64bit Windows and you have a REFPROP license, try installing the 64bit DLL from NIST. ");
+                return false;
+            }
+            if (setFunctionPointers(err) != true)
+            {
+                err = "There was an error setting the REFPROP function pointers, check types and names in header file.";
+                return false;
+            }
+            char rpv[versionstringlength] = { '\0' };
+            RPVersion(rpv, versionstringlength);
+            RPVersion_loaded = rpv;
+            return true;
+        }
+        return true;
+    }
+
+    bool unload_REFPROP(std::string &err)
+    {
+        // If REFPROP is loaded
+        if (RefpropdllInstance != NULL) {
+#if defined(__RPISWINDOWS__)
+            std::stringstream msg_stream;
+            if (!FreeLibrary(RefpropdllInstance)) 
+            {
+                msg_stream << GetLastError(); // returns error
+                err = msg_stream.str();
+                return false;
+            }
+#elif (defined(__RPISLINUX__) || defined(__RPISAPPLE__))
+            if (dlclose(RefpropdllInstance) != 0) 
+            {
+                const char* errstr = dlerror();
+                if (errstr != NULL) 
+                {
+                    err = errstr;
+                }
+                return false;
+            }
+#else
+            err = "Something is wrong with the platform definition, you should not end up here.";
+            return false;
+#endif
+            RefpropdllInstance = NULL;
+            RPVersion_loaded.clear();
+            RPPath_loaded.clear();
+        }
+        return true;
+    }
+
+    /// The address of the REFPROP instance
+    std::size_t REFPROP_address() {
+        return reinterpret_cast<std::size_t>(RefpropdllInstance);
+    }
+
+#endif // REFPROP_IMPLEMENTATION
+
+#ifdef REFPROP_LIB_NAMESPACE
+}; /* namespace REFPROP_LIB_NAMESPACE */
+#endif
+
+#endif // REFPROP_LIB_H

--- a/wrappers/C_CPP/refprop/include/Refprop/enum.h
+++ b/wrappers/C_CPP/refprop/include/Refprop/enum.h
@@ -1,0 +1,1331 @@
+// This file is part of Better Enums, released under the BSD 2-clause license.
+// See LICENSE.md for details, or visit http://github.com/aantron/better-enums.
+
+//#define BETTER_ENUMS_DEFAULT_CONSTRUCTOR(Enum) \
+//  public:                                      \
+//    Enum() = default;
+////FlagFlagsLib::Return_errors return_errors{};        // would be used like this
+
+#pragma once
+
+#ifndef BETTER_ENUMS_ENUM_H
+#define BETTER_ENUMS_ENUM_H
+
+
+
+#include <cstddef>
+#include <cstring>
+#include <iosfwd>
+#include <stdexcept>
+
+
+// in-line, non-#pragma warning handling
+// not supported in very old compilers (namely gcc 4.4 or less)
+#ifdef __GNUC__
+#   ifdef __clang__
+#      define BETTER_ENUMS_IGNORE_OLD_CAST_HEADER _Pragma("clang diagnostic push")
+#      define BETTER_ENUMS_IGNORE_OLD_CAST_BEGIN _Pragma("clang diagnostic ignored \"-Wold-style-cast\"")
+#      define BETTER_ENUMS_IGNORE_OLD_CAST_END _Pragma("clang diagnostic pop")
+#      define BETTER_ENUMS_IGNORE_ATTRIBUTES_HEADER
+#      define BETTER_ENUMS_IGNORE_ATTRIBUTES_BEGIN
+#      define BETTER_ENUMS_IGNORE_ATTRIBUTES_END
+#   else
+#      define BETTER_ENUMS_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100)
+#      if BETTER_ENUMS_GCC_VERSION > 40400
+#         define BETTER_ENUMS_IGNORE_OLD_CAST_HEADER _Pragma("GCC diagnostic push")
+#         define BETTER_ENUMS_IGNORE_OLD_CAST_BEGIN _Pragma("GCC diagnostic ignored \"-Wold-style-cast\"")
+#         define BETTER_ENUMS_IGNORE_OLD_CAST_END _Pragma("GCC diagnostic pop")
+#         if (BETTER_ENUMS_GCC_VERSION >= 70300)
+#               define BETTER_ENUMS_IGNORE_ATTRIBUTES_HEADER _Pragma("GCC diagnostic push")
+#               define BETTER_ENUMS_IGNORE_ATTRIBUTES_BEGIN _Pragma("GCC diagnostic ignored \"-Wattributes\"")
+#               define BETTER_ENUMS_IGNORE_ATTRIBUTES_END _Pragma("GCC diagnostic pop")
+#         else
+#               define BETTER_ENUMS_IGNORE_ATTRIBUTES_HEADER
+#               define BETTER_ENUMS_IGNORE_ATTRIBUTES_BEGIN
+#               define BETTER_ENUMS_IGNORE_ATTRIBUTES_END
+#         endif
+#      else
+#         define BETTER_ENUMS_IGNORE_OLD_CAST_HEADER
+#         define BETTER_ENUMS_IGNORE_OLD_CAST_BEGIN
+#         define BETTER_ENUMS_IGNORE_OLD_CAST_END
+#         define BETTER_ENUMS_IGNORE_ATTRIBUTES_HEADER
+#         define BETTER_ENUMS_IGNORE_ATTRIBUTES_BEGIN
+#         define BETTER_ENUMS_IGNORE_ATTRIBUTES_END
+#      endif
+#   endif
+#else // empty definitions for compilers that don't support _Pragma
+#   define BETTER_ENUMS_IGNORE_OLD_CAST_HEADER
+#   define BETTER_ENUMS_IGNORE_OLD_CAST_BEGIN
+#   define BETTER_ENUMS_IGNORE_OLD_CAST_END
+#   define BETTER_ENUMS_IGNORE_ATTRIBUTES_HEADER
+#   define BETTER_ENUMS_IGNORE_ATTRIBUTES_BEGIN
+#   define BETTER_ENUMS_IGNORE_ATTRIBUTES_END
+#endif
+
+// Feature detection.
+
+#ifdef __GNUC__
+#   ifdef __clang__
+#       if __has_feature(cxx_constexpr)
+#           define BETTER_ENUMS_HAVE_CONSTEXPR
+#       endif
+#       if !defined(__EXCEPTIONS) || !__has_feature(cxx_exceptions)
+#           define BETTER_ENUMS_NO_EXCEPTIONS
+#       endif
+#   else
+#       if defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L
+#           if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6))
+#               define BETTER_ENUMS_HAVE_CONSTEXPR
+#           endif
+#       endif
+#       ifndef __EXCEPTIONS
+#           define BETTER_ENUMS_NO_EXCEPTIONS
+#       endif
+#   endif
+#endif
+
+#ifdef _MSC_VER
+#   if _MSC_VER >= 1911
+#       define BETTER_ENUMS_HAVE_CONSTEXPR
+#   endif
+#   ifdef __clang__
+#       if __has_feature(cxx_constexpr)
+#           define BETTER_ENUMS_HAVE_CONSTEXPR
+#       endif
+#   endif
+#   ifndef _CPPUNWIND
+#       define BETTER_ENUMS_NO_EXCEPTIONS
+#   endif
+#   if _MSC_VER < 1600
+#       define BETTER_ENUMS_VC2008_WORKAROUNDS
+#   endif
+#endif
+
+#ifdef BETTER_ENUMS_CONSTEXPR
+#   define BETTER_ENUMS_HAVE_CONSTEXPR
+#endif
+
+#ifdef BETTER_ENUMS_NO_CONSTEXPR
+#   ifdef BETTER_ENUMS_HAVE_CONSTEXPR
+#       undef BETTER_ENUMS_HAVE_CONSTEXPR
+#   endif
+#endif
+
+// GCC (and maybe clang) can be made to warn about using 0 or NULL when nullptr
+// is available, so Better Enums tries to use nullptr. This passage uses
+// availability of constexpr as a proxy for availability of nullptr, i.e. it
+// assumes that nullptr is available when compiling on the right versions of gcc
+// and clang with the right -std flag. This is actually slightly wrong, because
+// nullptr is also available in Visual C++, but constexpr isn't. This
+// imprecision doesn't matter, however, because VC++ doesn't have the warnings
+// that make using nullptr necessary.
+#ifdef BETTER_ENUMS_HAVE_CONSTEXPR
+#   define BETTER_ENUMS_CONSTEXPR_     constexpr
+#   define BETTER_ENUMS_NULLPTR        nullptr
+#else
+#   define BETTER_ENUMS_CONSTEXPR_
+#   define BETTER_ENUMS_NULLPTR        NULL
+#endif
+
+#ifndef BETTER_ENUMS_NO_EXCEPTIONS
+#   define BETTER_ENUMS_IF_EXCEPTIONS(x) x
+#else
+#   define BETTER_ENUMS_IF_EXCEPTIONS(x)
+#endif
+
+#ifdef __GNUC__
+#   define BETTER_ENUMS_UNUSED __attribute__((__unused__))
+#else
+#   define BETTER_ENUMS_UNUSED
+#endif
+
+
+
+// Higher-order preprocessor macros.
+
+#ifdef BETTER_ENUMS_MACRO_FILE
+#   include BETTER_ENUMS_MACRO_FILE
+#else
+
+#define BETTER_ENUMS_PP_MAP(macro, data, ...) \
+    BETTER_ENUMS_ID( \
+        BETTER_ENUMS_APPLY( \
+            BETTER_ENUMS_PP_MAP_VAR_COUNT, \
+            BETTER_ENUMS_PP_COUNT(__VA_ARGS__)) \
+        (macro, data, __VA_ARGS__))
+
+#define BETTER_ENUMS_PP_MAP_VAR_COUNT(count) BETTER_ENUMS_M ## count
+
+#define BETTER_ENUMS_APPLY(macro, ...) BETTER_ENUMS_ID(macro(__VA_ARGS__))
+
+#define BETTER_ENUMS_ID(x) x
+
+#define BETTER_ENUMS_M1(m, d, x) m(d,0,x)
+#define BETTER_ENUMS_M2(m,d,x,...) m(d,1,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M1(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M3(m,d,x,...) m(d,2,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M2(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M4(m,d,x,...) m(d,3,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M3(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M5(m,d,x,...) m(d,4,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M4(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M6(m,d,x,...) m(d,5,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M5(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M7(m,d,x,...) m(d,6,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M6(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M8(m,d,x,...) m(d,7,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M7(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M9(m,d,x,...) m(d,8,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M8(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M10(m,d,x,...) m(d,9,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M9(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M11(m,d,x,...) m(d,10,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M10(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M12(m,d,x,...) m(d,11,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M11(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M13(m,d,x,...) m(d,12,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M12(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M14(m,d,x,...) m(d,13,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M13(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M15(m,d,x,...) m(d,14,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M14(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M16(m,d,x,...) m(d,15,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M15(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M17(m,d,x,...) m(d,16,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M16(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M18(m,d,x,...) m(d,17,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M17(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M19(m,d,x,...) m(d,18,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M18(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M20(m,d,x,...) m(d,19,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M19(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M21(m,d,x,...) m(d,20,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M20(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M22(m,d,x,...) m(d,21,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M21(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M23(m,d,x,...) m(d,22,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M22(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M24(m,d,x,...) m(d,23,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M23(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M25(m,d,x,...) m(d,24,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M24(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M26(m,d,x,...) m(d,25,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M25(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M27(m,d,x,...) m(d,26,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M26(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M28(m,d,x,...) m(d,27,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M27(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M29(m,d,x,...) m(d,28,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M28(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M30(m,d,x,...) m(d,29,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M29(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M31(m,d,x,...) m(d,30,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M30(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M32(m,d,x,...) m(d,31,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M31(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M33(m,d,x,...) m(d,32,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M32(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M34(m,d,x,...) m(d,33,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M33(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M35(m,d,x,...) m(d,34,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M34(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M36(m,d,x,...) m(d,35,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M35(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M37(m,d,x,...) m(d,36,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M36(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M38(m,d,x,...) m(d,37,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M37(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M39(m,d,x,...) m(d,38,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M38(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M40(m,d,x,...) m(d,39,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M39(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M41(m,d,x,...) m(d,40,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M40(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M42(m,d,x,...) m(d,41,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M41(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M43(m,d,x,...) m(d,42,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M42(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M44(m,d,x,...) m(d,43,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M43(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M45(m,d,x,...) m(d,44,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M44(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M46(m,d,x,...) m(d,45,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M45(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M47(m,d,x,...) m(d,46,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M46(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M48(m,d,x,...) m(d,47,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M47(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M49(m,d,x,...) m(d,48,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M48(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M50(m,d,x,...) m(d,49,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M49(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M51(m,d,x,...) m(d,50,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M50(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M52(m,d,x,...) m(d,51,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M51(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M53(m,d,x,...) m(d,52,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M52(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M54(m,d,x,...) m(d,53,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M53(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M55(m,d,x,...) m(d,54,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M54(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M56(m,d,x,...) m(d,55,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M55(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M57(m,d,x,...) m(d,56,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M56(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M58(m,d,x,...) m(d,57,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M57(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M59(m,d,x,...) m(d,58,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M58(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M60(m,d,x,...) m(d,59,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M59(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M61(m,d,x,...) m(d,60,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M60(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M62(m,d,x,...) m(d,61,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M61(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M63(m,d,x,...) m(d,62,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M62(m,d,__VA_ARGS__))
+#define BETTER_ENUMS_M64(m,d,x,...) m(d,63,x) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_M63(m,d,__VA_ARGS__))
+
+#define BETTER_ENUMS_PP_COUNT_IMPL(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10,    \
+    _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, \
+    _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
+    _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, \
+    _56, _57, _58, _59, _60, _61, _62, _63, _64, count, ...) count
+
+#define BETTER_ENUMS_PP_COUNT(...) \
+    BETTER_ENUMS_ID(BETTER_ENUMS_PP_COUNT_IMPL(__VA_ARGS__, 64, 63, 62, 61, 60,\
+        59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42,\
+        41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24,\
+        23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, \
+        4, 3, 2, 1))
+
+#define BETTER_ENUMS_ITERATE(X, f, l) X(f, l, 0) X(f, l, 1) X(f, l, 2)         \
+    X(f, l, 3) X(f, l, 4) X(f, l, 5) X(f, l, 6) X(f, l, 7) X(f, l, 8)          \
+    X(f, l, 9) X(f, l, 10) X(f, l, 11) X(f, l, 12) X(f, l, 13) X(f, l, 14)     \
+    X(f, l, 15) X(f, l, 16) X(f, l, 17) X(f, l, 18) X(f, l, 19) X(f, l, 20)    \
+    X(f, l, 21) X(f, l, 22) X(f, l, 23)
+
+#endif // #ifdef BETTER_ENUMS_MACRO_FILE else case
+
+
+
+namespace better_enums {
+
+
+// Optional type.
+
+template <typename T>
+BETTER_ENUMS_CONSTEXPR_ inline T _default()
+{
+    return static_cast<typename T::_enumerated>(0);
+}
+
+template <>
+BETTER_ENUMS_CONSTEXPR_ inline const char* _default<const char*>()
+{
+    return BETTER_ENUMS_NULLPTR;
+}
+
+template <>
+BETTER_ENUMS_CONSTEXPR_ inline std::size_t _default<std::size_t>()
+{
+    return 0;
+}
+
+template <typename T>
+struct optional {
+    BETTER_ENUMS_CONSTEXPR_ optional() :
+        _valid(false), _value(_default<T>()) { }
+
+    BETTER_ENUMS_CONSTEXPR_ optional(T v) : _valid(true), _value(v) { }
+
+    BETTER_ENUMS_CONSTEXPR_ const T& operator *() const { return _value; }
+    BETTER_ENUMS_CONSTEXPR_ const T* operator ->() const { return &_value; }
+
+    BETTER_ENUMS_CONSTEXPR_ operator bool() const { return _valid; }
+
+    BETTER_ENUMS_CONSTEXPR_ const T& value() const { return _value; }
+
+  private:
+    bool    _valid;
+    T       _value;
+};
+
+template <typename CastTo, typename Element>
+BETTER_ENUMS_CONSTEXPR_ static optional<CastTo>
+_map_index(const Element *array, optional<std::size_t> index)
+{
+    return index ? static_cast<CastTo>(array[*index]) : optional<CastTo>();
+}
+
+#ifdef BETTER_ENUMS_VC2008_WORKAROUNDS
+
+#define BETTER_ENUMS_OR_THROW                                                  \
+    if (!maybe)                                                                \
+        throw std::runtime_error(message);                                     \
+                                                                               \
+    return *maybe;
+
+#else
+
+#define BETTER_ENUMS_OR_THROW                                                  \
+    return maybe ? *maybe : throw std::runtime_error(message);
+
+#endif
+
+BETTER_ENUMS_IF_EXCEPTIONS(
+template <typename T>
+BETTER_ENUMS_CONSTEXPR_ static T _or_throw(optional<T> maybe,
+                                           const char *message)
+{
+    BETTER_ENUMS_OR_THROW
+}
+)
+
+template <typename T>
+BETTER_ENUMS_CONSTEXPR_ static T* _or_null(optional<T*> maybe)
+{
+    return maybe ? *maybe : BETTER_ENUMS_NULLPTR;
+}
+
+template <typename T>
+BETTER_ENUMS_CONSTEXPR_ static T _or_zero(optional<T> maybe)
+{
+    return maybe ? *maybe : T::_from_integral_unchecked(0);
+}
+
+
+
+// Functional sequencing. This is essentially a comma operator wrapped in a
+// constexpr function. g++ 4.7 doesn't "accept" integral constants in the second
+// position for the comma operator, and emits an external symbol, which then
+// causes a linking error.
+
+template <typename T, typename U>
+BETTER_ENUMS_CONSTEXPR_ U
+continue_with(T, U value) { return value; }
+
+
+
+// Values array declaration helper.
+
+//! Get intrinsic value of an (Enum::value) by taking advantage of
+// C-conversion's parentheses priority
+template <typename EnumType>
+struct _eat_assign {
+    explicit BETTER_ENUMS_CONSTEXPR_ _eat_assign(EnumType value) : _value(value)
+        { }
+
+    template <typename Any>
+    BETTER_ENUMS_CONSTEXPR_ const _eat_assign&
+    operator =(Any) const { return *this; }
+
+    BETTER_ENUMS_CONSTEXPR_ operator EnumType () const { return _value; }
+
+  private:
+    EnumType    _value;
+};
+
+
+
+// Iterables.
+
+template <typename Element>
+struct _iterable {
+    typedef const Element*  iterator;
+
+    BETTER_ENUMS_CONSTEXPR_ iterator begin() const { return iterator(_array); }
+    BETTER_ENUMS_CONSTEXPR_ iterator end() const
+        { return iterator(_array + _size); }
+    BETTER_ENUMS_CONSTEXPR_ std::size_t size() const { return _size; }
+    BETTER_ENUMS_CONSTEXPR_ const Element& operator [](std::size_t index) const
+        { return _array[index]; }
+
+    BETTER_ENUMS_CONSTEXPR_ _iterable(const Element *array, std::size_t s) :
+        _array(array), _size(s) { }
+
+  private:
+    const Element * const   _array;
+    const std::size_t       _size;
+};
+
+
+
+// String routines.
+
+BETTER_ENUMS_CONSTEXPR_ static const char       *_name_enders = "= \t\n";
+
+BETTER_ENUMS_CONSTEXPR_ inline bool _ends_name(char c, std::size_t index = 0)
+{
+    return
+        c == _name_enders[index] ? true  :
+        _name_enders[index] == '\0' ? false :
+        _ends_name(c, index + 1);
+}
+
+BETTER_ENUMS_CONSTEXPR_ inline bool _has_initializer(const char *s,
+                                                     std::size_t index = 0)
+{
+    return
+        s[index] == '\0' ? false :
+        s[index] == '=' ? true :
+        _has_initializer(s, index + 1);
+}
+
+BETTER_ENUMS_CONSTEXPR_ inline std::size_t
+_constant_length(const char *s, std::size_t index = 0)
+{
+    return _ends_name(s[index]) ? index : _constant_length(s, index + 1);
+}
+
+BETTER_ENUMS_CONSTEXPR_ inline char
+_select(const char *from, std::size_t from_length, std::size_t index)
+{
+    return index >= from_length ? '\0' : from[index];
+}
+
+BETTER_ENUMS_CONSTEXPR_ inline char _to_lower_ascii(char c)
+{
+    return c >= 0x41 && c <= 0x5A ? static_cast<char>(c + 0x20) : c;
+}
+
+BETTER_ENUMS_CONSTEXPR_ inline bool _names_match(const char *stringizedName,
+                                                 const char *referenceName,
+                                                 std::size_t index = 0)
+{
+    return
+        _ends_name(stringizedName[index]) ? referenceName[index] == '\0' :
+        referenceName[index] == '\0' ? false :
+        stringizedName[index] != referenceName[index] ? false :
+        _names_match(stringizedName, referenceName, index + 1);
+}
+
+BETTER_ENUMS_CONSTEXPR_ inline bool
+_names_match_nocase(const char *stringizedName, const char *referenceName,
+                    std::size_t index = 0)
+{
+    return
+        _ends_name(stringizedName[index]) ? referenceName[index] == '\0' :
+        referenceName[index] == '\0' ? false :
+        _to_lower_ascii(stringizedName[index]) !=
+            _to_lower_ascii(referenceName[index]) ? false :
+        _names_match_nocase(stringizedName, referenceName, index + 1);
+}
+
+inline void _trim_names(const char * const *raw_names,
+                        const char **trimmed_names,
+                        char *storage, std::size_t count)
+{
+    std::size_t     offset = 0;
+
+    for (std::size_t index = 0; index < count; ++index) {
+        trimmed_names[index] = storage + offset;
+
+        std::size_t trimmed_length =
+            std::strcspn(raw_names[index], _name_enders);
+        storage[offset + trimmed_length] = '\0';
+
+        std::size_t raw_length = std::strlen(raw_names[index]);
+        offset += raw_length + 1;
+    }
+}
+
+
+
+// Eager initialization.
+template <typename Enum>
+struct _initialize_at_program_start {
+    _initialize_at_program_start() { Enum::initialize(); }
+};
+
+} // namespace better_enums
+
+
+
+// Array generation macros.
+
+#define BETTER_ENUMS_EAT_ASSIGN_SINGLE(EnumType, index, expression)            \
+    (EnumType)((::better_enums::_eat_assign<EnumType>)EnumType::expression),
+
+#define BETTER_ENUMS_EAT_ASSIGN(EnumType, ...)                                 \
+    BETTER_ENUMS_ID(                                                           \
+        BETTER_ENUMS_PP_MAP(                                                   \
+            BETTER_ENUMS_EAT_ASSIGN_SINGLE, EnumType, __VA_ARGS__))
+
+
+
+#ifdef BETTER_ENUMS_HAVE_CONSTEXPR
+
+
+
+#define BETTER_ENUMS_SELECT_SINGLE_CHARACTER(from, from_length, index)         \
+    ::better_enums::_select(from, from_length, index),
+
+#define BETTER_ENUMS_SELECT_CHARACTERS(from, from_length)                      \
+    BETTER_ENUMS_ITERATE(                                                      \
+        BETTER_ENUMS_SELECT_SINGLE_CHARACTER, from, from_length)
+
+
+
+#define BETTER_ENUMS_TRIM_SINGLE_STRING(ignored, index, expression)            \
+constexpr std::size_t   _length_ ## index =                                    \
+    ::better_enums::_constant_length(#expression);                             \
+constexpr const char    _trimmed_ ## index [] =                                \
+    { BETTER_ENUMS_SELECT_CHARACTERS(#expression, _length_ ## index) };        \
+constexpr const char    *_final_ ## index =                                    \
+    ::better_enums::_has_initializer(#expression) ?                            \
+        _trimmed_ ## index : #expression;
+
+#define BETTER_ENUMS_TRIM_STRINGS(...)                                         \
+    BETTER_ENUMS_ID(                                                           \
+        BETTER_ENUMS_PP_MAP(                                                   \
+            BETTER_ENUMS_TRIM_SINGLE_STRING, ignored, __VA_ARGS__))
+
+
+
+#define BETTER_ENUMS_REFER_TO_SINGLE_STRING(ignored, index, expression)        \
+    _final_ ## index,
+
+#define BETTER_ENUMS_REFER_TO_STRINGS(...)                                     \
+    BETTER_ENUMS_ID(                                                           \
+        BETTER_ENUMS_PP_MAP(                                                   \
+            BETTER_ENUMS_REFER_TO_SINGLE_STRING, ignored, __VA_ARGS__))
+
+
+
+#endif // #ifdef BETTER_ENUMS_HAVE_CONSTEXPR
+
+
+
+#define BETTER_ENUMS_STRINGIZE_SINGLE(ignored, index, expression)  #expression,
+
+#define BETTER_ENUMS_STRINGIZE(...)                                            \
+    BETTER_ENUMS_ID(                                                           \
+        BETTER_ENUMS_PP_MAP(                                                   \
+            BETTER_ENUMS_STRINGIZE_SINGLE, ignored, __VA_ARGS__))
+
+#define BETTER_ENUMS_RESERVE_STORAGE_SINGLE(ignored, index, expression)        \
+    #expression ","
+
+#define BETTER_ENUMS_RESERVE_STORAGE(...)                                      \
+    BETTER_ENUMS_ID(                                                           \
+        BETTER_ENUMS_PP_MAP(                                                   \
+            BETTER_ENUMS_RESERVE_STORAGE_SINGLE, ignored, __VA_ARGS__))
+
+
+
+// The enums proper.
+
+#define BETTER_ENUMS_NS(EnumType)  better_enums_data_ ## EnumType
+
+#ifdef BETTER_ENUMS_VC2008_WORKAROUNDS
+
+#define BETTER_ENUMS_COPY_CONSTRUCTOR(Enum)                                    \
+        BETTER_ENUMS_CONSTEXPR_ Enum(const Enum &other) :                      \
+            _value(other._value) { }
+
+#else
+
+#define BETTER_ENUMS_COPY_CONSTRUCTOR(Enum)
+
+#endif
+
+#ifndef BETTER_ENUMS_CLASS_ATTRIBUTE
+#   define BETTER_ENUMS_CLASS_ATTRIBUTE
+#endif
+
+#define BETTER_ENUMS_TYPE(SetUnderlyingType, SwitchType, GenerateSwitchType,   \
+                          GenerateStrings, ToStringConstexpr,                  \
+                          DeclareInitialize, DefineInitialize, CallInitialize, \
+                          Enum, Underlying, ...)                               \
+                                                                               \
+namespace better_enums_data_ ## Enum {                                         \
+                                                                               \
+BETTER_ENUMS_ID(GenerateSwitchType(Underlying, __VA_ARGS__))                   \
+                                                                               \
+}                                                                              \
+                                                                               \
+class BETTER_ENUMS_CLASS_ATTRIBUTE Enum {                                      \
+  private:                                                                     \
+    typedef ::better_enums::optional<Enum>                  _optional;         \
+    typedef ::better_enums::optional<std::size_t>           _optional_index;   \
+                                                                               \
+  public:                                                                      \
+    typedef Underlying                                      _integral;         \
+                                                                               \
+    enum _enumerated SetUnderlyingType(Underlying) { __VA_ARGS__ };            \
+                                                                               \
+    BETTER_ENUMS_CONSTEXPR_ Enum(_enumerated value) : _value(value) { }        \
+                                                                               \
+    BETTER_ENUMS_COPY_CONSTRUCTOR(Enum)                                        \
+                                                                               \
+    BETTER_ENUMS_CONSTEXPR_ operator SwitchType(Enum)() const                  \
+    {                                                                          \
+        return SwitchType(Enum)(_value);                                       \
+    }                                                                          \
+                                                                               \
+    BETTER_ENUMS_CONSTEXPR_ _integral _to_integral() const;                    \
+    BETTER_ENUMS_IF_EXCEPTIONS(                                                \
+    BETTER_ENUMS_CONSTEXPR_ static Enum _from_integral(_integral value);       \
+    )                                                                          \
+    BETTER_ENUMS_CONSTEXPR_ static Enum                                        \
+    _from_integral_unchecked(_integral value);                                 \
+    BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
+    _from_integral_nothrow(_integral value);                                   \
+                                                                               \
+    BETTER_ENUMS_CONSTEXPR_ std::size_t _to_index() const;                     \
+    BETTER_ENUMS_IF_EXCEPTIONS(                                                \
+    BETTER_ENUMS_CONSTEXPR_ static Enum _from_index(std::size_t index);        \
+    )                                                                          \
+    BETTER_ENUMS_CONSTEXPR_ static Enum                                        \
+    _from_index_unchecked(std::size_t index);                                  \
+    BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
+    _from_index_nothrow(std::size_t index);                                    \
+                                                                               \
+    ToStringConstexpr const char* _to_string() const;                          \
+    BETTER_ENUMS_IF_EXCEPTIONS(                                                \
+    BETTER_ENUMS_CONSTEXPR_ static Enum _from_string(const char *name);        \
+    )                                                                          \
+    BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
+    _from_string_nothrow(const char *name);                                    \
+                                                                               \
+    BETTER_ENUMS_IF_EXCEPTIONS(                                                \
+    BETTER_ENUMS_CONSTEXPR_ static Enum _from_string_nocase(const char *name); \
+    )                                                                          \
+    BETTER_ENUMS_CONSTEXPR_ static _optional                                   \
+    _from_string_nocase_nothrow(const char *name);                             \
+                                                                               \
+    BETTER_ENUMS_CONSTEXPR_ static bool _is_valid(_integral value);            \
+    BETTER_ENUMS_CONSTEXPR_ static bool _is_valid(const char *name);           \
+    BETTER_ENUMS_CONSTEXPR_ static bool _is_valid_nocase(const char *name);    \
+                                                                               \
+    typedef ::better_enums::_iterable<Enum>             _value_iterable;       \
+    typedef ::better_enums::_iterable<const char*>      _name_iterable;        \
+                                                                               \
+    typedef _value_iterable::iterator                   _value_iterator;       \
+    typedef _name_iterable::iterator                    _name_iterator;        \
+                                                                               \
+    BETTER_ENUMS_CONSTEXPR_ static const std::size_t _size_constant =          \
+        BETTER_ENUMS_ID(BETTER_ENUMS_PP_COUNT(__VA_ARGS__));                   \
+    BETTER_ENUMS_CONSTEXPR_ static std::size_t _size()                         \
+        { return _size_constant; }                                             \
+                                                                               \
+    BETTER_ENUMS_CONSTEXPR_ static const char* _name();                        \
+    BETTER_ENUMS_CONSTEXPR_ static _value_iterable _values();                  \
+    ToStringConstexpr static _name_iterable _names();                          \
+                                                                               \
+    _integral      _value;                                                     \
+                                                                               \
+    BETTER_ENUMS_DEFAULT_CONSTRUCTOR(Enum)                                     \
+                                                                               \
+  private:                                                                     \
+    explicit BETTER_ENUMS_CONSTEXPR_ Enum(const _integral &value) :            \
+        _value(value) { }                                                      \
+                                                                               \
+    DeclareInitialize                                                          \
+                                                                               \
+    BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
+    _from_value_loop(_integral value, std::size_t index = 0);                  \
+    BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
+    _from_string_loop(const char *name, std::size_t index = 0);                \
+    BETTER_ENUMS_CONSTEXPR_ static _optional_index                             \
+    _from_string_nocase_loop(const char *name, std::size_t index = 0);         \
+                                                                               \
+    friend struct ::better_enums::_initialize_at_program_start<Enum>;          \
+};                                                                             \
+                                                                               \
+namespace better_enums_data_ ## Enum {                                         \
+                                                                               \
+static ::better_enums::_initialize_at_program_start<Enum>                      \
+                                                _force_initialization;         \
+                                                                               \
+enum _putNamesInThisScopeAlso { __VA_ARGS__ };                                 \
+                                                                               \
+BETTER_ENUMS_IGNORE_OLD_CAST_HEADER                                            \
+BETTER_ENUMS_IGNORE_OLD_CAST_BEGIN                                             \
+BETTER_ENUMS_CONSTEXPR_ const Enum      _value_array[] =                       \
+    { BETTER_ENUMS_ID(BETTER_ENUMS_EAT_ASSIGN(Enum, __VA_ARGS__)) };           \
+BETTER_ENUMS_IGNORE_OLD_CAST_END                                               \
+                                                                               \
+BETTER_ENUMS_ID(GenerateStrings(Enum, __VA_ARGS__))                            \
+                                                                               \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_IGNORE_ATTRIBUTES_HEADER                                          \
+BETTER_ENUMS_IGNORE_ATTRIBUTES_BEGIN                                           \
+BETTER_ENUMS_UNUSED BETTER_ENUMS_CONSTEXPR_                                    \
+inline const Enum                                                              \
+operator +(Enum::_enumerated enumerated)                                       \
+{                                                                              \
+    return static_cast<Enum>(enumerated);                                      \
+}                                                                              \
+BETTER_ENUMS_IGNORE_ATTRIBUTES_END                                             \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional_index                           \
+Enum::_from_value_loop(Enum::_integral value, std::size_t index)               \
+{                                                                              \
+    return                                                                     \
+        index == _size() ?                                                     \
+            _optional_index() :                                                \
+            BETTER_ENUMS_NS(Enum)::_value_array[index]._value == value ?       \
+                _optional_index(index) :                                       \
+                _from_value_loop(value, index + 1);                            \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional_index                           \
+Enum::_from_string_loop(const char *name, std::size_t index)                   \
+{                                                                              \
+    return                                                                     \
+        index == _size() ? _optional_index() :                                 \
+        ::better_enums::_names_match(                                          \
+            BETTER_ENUMS_NS(Enum)::_raw_names()[index], name) ?                \
+            _optional_index(index) :                                           \
+            _from_string_loop(name, index + 1);                                \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional_index                           \
+Enum::_from_string_nocase_loop(const char *name, std::size_t index)            \
+{                                                                              \
+    return                                                                     \
+        index == _size() ? _optional_index() :                                 \
+            ::better_enums::_names_match_nocase(                               \
+                BETTER_ENUMS_NS(Enum)::_raw_names()[index], name) ?            \
+                    _optional_index(index) :                                   \
+                    _from_string_nocase_loop(name, index + 1);                 \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_integral Enum::_to_integral() const      \
+{                                                                              \
+    return _integral(_value);                                                  \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline std::size_t Enum::_to_index() const             \
+{                                                                              \
+    return *_from_value_loop(_value);                                          \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum                                            \
+Enum::_from_index_unchecked(std::size_t index)                                 \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_or_zero(_from_index_nothrow(index));                  \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
+Enum::_from_index_nothrow(std::size_t index)                                   \
+{                                                                              \
+    return                                                                     \
+        index >= _size() ?                                                     \
+            _optional() :                                                      \
+             _optional(BETTER_ENUMS_NS(Enum)::_value_array[index]);            \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_IF_EXCEPTIONS(                                                    \
+BETTER_ENUMS_CONSTEXPR_ inline Enum Enum::_from_index(std::size_t index)       \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_or_throw(_from_index_nothrow(index),                  \
+                                  #Enum "::_from_index: invalid argument");    \
+}                                                                              \
+)                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum                                            \
+Enum::_from_integral_unchecked(_integral value)                                \
+{                                                                              \
+    return static_cast<_enumerated>(value);                                    \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
+Enum::_from_integral_nothrow(_integral value)                                  \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_map_index<Enum>(BETTER_ENUMS_NS(Enum)::_value_array,  \
+                                         _from_value_loop(value));             \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_IF_EXCEPTIONS(                                                    \
+BETTER_ENUMS_CONSTEXPR_ inline Enum Enum::_from_integral(_integral value)      \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_or_throw(_from_integral_nothrow(value),               \
+                                  #Enum "::_from_integral: invalid argument"); \
+}                                                                              \
+)                                                                              \
+                                                                               \
+ToStringConstexpr inline const char* Enum::_to_string() const                  \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_or_null(                                              \
+            ::better_enums::_map_index<const char*>(                           \
+                BETTER_ENUMS_NS(Enum)::_name_array(),                          \
+                _from_value_loop(CallInitialize(_value))));                    \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
+Enum::_from_string_nothrow(const char *name)                                   \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_map_index<Enum>(                                      \
+            BETTER_ENUMS_NS(Enum)::_value_array, _from_string_loop(name));     \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_IF_EXCEPTIONS(                                                    \
+BETTER_ENUMS_CONSTEXPR_ inline Enum Enum::_from_string(const char *name)       \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_or_throw(_from_string_nothrow(name),                  \
+                                  #Enum "::_from_string: invalid argument");   \
+}                                                                              \
+)                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_optional                                 \
+Enum::_from_string_nocase_nothrow(const char *name)                            \
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_map_index<Enum>(BETTER_ENUMS_NS(Enum)::_value_array,  \
+                                         _from_string_nocase_loop(name));      \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_IF_EXCEPTIONS(                                                    \
+BETTER_ENUMS_CONSTEXPR_ inline Enum Enum::_from_string_nocase(const char *name)\
+{                                                                              \
+    return                                                                     \
+        ::better_enums::_or_throw(                                             \
+            _from_string_nocase_nothrow(name),                                 \
+            #Enum "::_from_string_nocase: invalid argument");                  \
+}                                                                              \
+)                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline bool Enum::_is_valid(_integral value)           \
+{                                                                              \
+    return _from_value_loop(value);                                            \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline bool Enum::_is_valid(const char *name)          \
+{                                                                              \
+    return _from_string_loop(name);                                            \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline bool Enum::_is_valid_nocase(const char *name)   \
+{                                                                              \
+    return _from_string_nocase_loop(name);                                     \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline const char* Enum::_name()                       \
+{                                                                              \
+    return #Enum;                                                              \
+}                                                                              \
+                                                                               \
+BETTER_ENUMS_CONSTEXPR_ inline Enum::_value_iterable Enum::_values()           \
+{                                                                              \
+    return _value_iterable(BETTER_ENUMS_NS(Enum)::_value_array, _size());      \
+}                                                                              \
+                                                                               \
+ToStringConstexpr inline Enum::_name_iterable Enum::_names()                   \
+{                                                                              \
+    return                                                                     \
+        _name_iterable(BETTER_ENUMS_NS(Enum)::_name_array(),                   \
+                       CallInitialize(_size()));                               \
+}                                                                              \
+                                                                               \
+DefineInitialize(Enum)                                                         \
+                                                                               \
+BETTER_ENUMS_IGNORE_ATTRIBUTES_HEADER                                          \
+BETTER_ENUMS_IGNORE_ATTRIBUTES_BEGIN                                           \
+BETTER_ENUMS_UNUSED BETTER_ENUMS_CONSTEXPR_                                    \
+inline bool operator ==(const Enum &a, const Enum &b)                          \
+    { return a._to_integral() == b._to_integral(); }                           \
+                                                                               \
+BETTER_ENUMS_UNUSED BETTER_ENUMS_CONSTEXPR_                                    \
+inline bool operator !=(const Enum &a, const Enum &b)                          \
+    { return a._to_integral() != b._to_integral(); }                           \
+                                                                               \
+BETTER_ENUMS_UNUSED BETTER_ENUMS_CONSTEXPR_                                    \
+inline bool operator <(const Enum &a, const Enum &b)                           \
+    { return a._to_integral() < b._to_integral(); }                            \
+                                                                               \
+BETTER_ENUMS_UNUSED BETTER_ENUMS_CONSTEXPR_                                    \
+inline bool operator <=(const Enum &a, const Enum &b)                          \
+    { return a._to_integral() <= b._to_integral(); }                           \
+                                                                               \
+BETTER_ENUMS_UNUSED BETTER_ENUMS_CONSTEXPR_                                    \
+inline bool operator >(const Enum &a, const Enum &b)                           \
+    { return a._to_integral() > b._to_integral(); }                            \
+                                                                               \
+BETTER_ENUMS_UNUSED BETTER_ENUMS_CONSTEXPR_                                    \
+inline bool operator >=(const Enum &a, const Enum &b)                          \
+    { return a._to_integral() >= b._to_integral(); }                           \
+BETTER_ENUMS_IGNORE_ATTRIBUTES_END                                             \
+                                                                               \
+                                                                               \
+template <typename Char, typename Traits>                                      \
+std::basic_ostream<Char, Traits>&                                              \
+operator <<(std::basic_ostream<Char, Traits>& stream, const Enum &value)       \
+{                                                                              \
+    return stream << value._to_string();                                       \
+}                                                                              \
+                                                                               \
+template <typename Char, typename Traits>                                      \
+std::basic_istream<Char, Traits>&                                              \
+operator >>(std::basic_istream<Char, Traits>& stream, Enum &value)             \
+{                                                                              \
+    std::basic_string<Char, Traits>     buffer;                                \
+                                                                               \
+    stream >> buffer;                                                          \
+    ::better_enums::optional<Enum>      converted =                            \
+        Enum::_from_string_nothrow(buffer.c_str());                            \
+                                                                               \
+    if (converted)                                                             \
+        value = *converted;                                                    \
+    else                                                                       \
+        stream.setstate(std::basic_istream<Char, Traits>::failbit);            \
+                                                                               \
+    return stream;                                                             \
+}
+
+
+
+// Enum feature options.
+
+// C++98, C++11
+#define BETTER_ENUMS_CXX98_UNDERLYING_TYPE(Underlying)
+
+// C++11
+#define BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)                         \
+    : Underlying
+
+#if defined(_MSC_VER) && _MSC_VER >= 1700
+// VS 2012 and above fully support strongly typed enums and will warn about
+// incorrect usage.
+#   define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) \
+        BETTER_ENUMS_CXX11_UNDERLYING_TYPE(Underlying)
+#else
+#   define BETTER_ENUMS_LEGACY_UNDERLYING_TYPE(Underlying) \
+        BETTER_ENUMS_CXX98_UNDERLYING_TYPE(Underlying)
+#endif
+
+// C++98, C++11
+#define BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE(Type)                            \
+    _enumerated
+
+// C++11
+#define BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE(Type)                              \
+    BETTER_ENUMS_NS(Type)::_enumClassForSwitchStatements
+
+// C++98, C++11
+#define BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE_GENERATE(Underlying, ...)
+
+// C++11
+#define BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE_GENERATE(Underlying, ...)          \
+    enum class _enumClassForSwitchStatements : Underlying { __VA_ARGS__ };
+
+// C++98
+#define BETTER_ENUMS_CXX98_TRIM_STRINGS_ARRAYS(Enum, ...)                      \
+    inline const char** _raw_names()                                           \
+    {                                                                          \
+        static const char   *value[] =                                         \
+            { BETTER_ENUMS_ID(BETTER_ENUMS_STRINGIZE(__VA_ARGS__)) };          \
+        return value;                                                          \
+    }                                                                          \
+                                                                               \
+    inline char* _name_storage()                                               \
+    {                                                                          \
+        static char         storage[] =                                        \
+            BETTER_ENUMS_ID(BETTER_ENUMS_RESERVE_STORAGE(__VA_ARGS__));        \
+        return storage;                                                        \
+    }                                                                          \
+                                                                               \
+    inline const char** _name_array()                                          \
+    {                                                                          \
+        static const char   *value[Enum::_size_constant];                      \
+        return value;                                                          \
+    }                                                                          \
+                                                                               \
+    inline bool& _initialized()                                                \
+    {                                                                          \
+        static bool         value = false;                                     \
+        return value;                                                          \
+    }
+
+// C++11 fast version
+#define BETTER_ENUMS_CXX11_PARTIAL_CONSTEXPR_TRIM_STRINGS_ARRAYS(Enum, ...)    \
+    constexpr const char    *_the_raw_names[] =                                \
+        { BETTER_ENUMS_ID(BETTER_ENUMS_STRINGIZE(__VA_ARGS__)) };              \
+                                                                               \
+    constexpr const char * const * _raw_names()                                \
+    {                                                                          \
+        return _the_raw_names;                                                 \
+    }                                                                          \
+                                                                               \
+    inline char* _name_storage()                                               \
+    {                                                                          \
+        static char         storage[] =                                        \
+            BETTER_ENUMS_ID(BETTER_ENUMS_RESERVE_STORAGE(__VA_ARGS__));        \
+        return storage;                                                        \
+    }                                                                          \
+                                                                               \
+    inline const char** _name_array()                                          \
+    {                                                                          \
+        static const char   *value[Enum::_size_constant];                      \
+        return value;                                                          \
+    }                                                                          \
+                                                                               \
+    inline bool& _initialized()                                                \
+    {                                                                          \
+        static bool         value = false;                                     \
+        return value;                                                          \
+    }
+
+// C++11 slow all-constexpr version
+#define BETTER_ENUMS_CXX11_FULL_CONSTEXPR_TRIM_STRINGS_ARRAYS(Enum, ...)       \
+    BETTER_ENUMS_ID(BETTER_ENUMS_TRIM_STRINGS(__VA_ARGS__))                    \
+                                                                               \
+    constexpr const char * const    _the_name_array[] =                        \
+        { BETTER_ENUMS_ID(BETTER_ENUMS_REFER_TO_STRINGS(__VA_ARGS__)) };       \
+                                                                               \
+    constexpr const char * const * _name_array()                               \
+    {                                                                          \
+        return _the_name_array;                                                \
+    }                                                                          \
+                                                                               \
+    constexpr const char * const * _raw_names()                                \
+    {                                                                          \
+        return _the_name_array;                                                \
+    }
+
+// C++98, C++11 fast version
+#define BETTER_ENUMS_NO_CONSTEXPR_TO_STRING_KEYWORD
+
+// C++11 slow all-constexpr version
+#define BETTER_ENUMS_CONSTEXPR_TO_STRING_KEYWORD                               \
+    constexpr
+
+// C++98, C++11 fast version
+#define BETTER_ENUMS_DO_DECLARE_INITIALIZE                                     \
+    static int initialize();
+
+// C++11 slow all-constexpr version
+#define BETTER_ENUMS_DECLARE_EMPTY_INITIALIZE                                  \
+    static int initialize() { return 0; }
+
+// C++98, C++11 fast version
+#define BETTER_ENUMS_DO_DEFINE_INITIALIZE(Enum)                                \
+    inline int Enum::initialize()                                              \
+    {                                                                          \
+        if (BETTER_ENUMS_NS(Enum)::_initialized())                             \
+            return 0;                                                          \
+                                                                               \
+        ::better_enums::_trim_names(BETTER_ENUMS_NS(Enum)::_raw_names(),       \
+                                    BETTER_ENUMS_NS(Enum)::_name_array(),      \
+                                    BETTER_ENUMS_NS(Enum)::_name_storage(),    \
+                                    _size());                                  \
+                                                                               \
+        BETTER_ENUMS_NS(Enum)::_initialized() = true;                          \
+                                                                               \
+        return 0;                                                              \
+    }
+
+// C++11 slow all-constexpr version
+#define BETTER_ENUMS_DO_NOT_DEFINE_INITIALIZE(Enum)
+
+// C++98, C++11 fast version
+#define BETTER_ENUMS_DO_CALL_INITIALIZE(value)                                 \
+    ::better_enums::continue_with(initialize(), value)
+
+// C++11 slow all-constexpr version
+#define BETTER_ENUMS_DO_NOT_CALL_INITIALIZE(value)                             \
+    value
+
+
+
+// User feature selection.
+
+#ifdef BETTER_ENUMS_STRICT_CONVERSION
+#   define BETTER_ENUMS_DEFAULT_SWITCH_TYPE                                    \
+        BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE
+#   define BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE                           \
+        BETTER_ENUMS_ENUM_CLASS_SWITCH_TYPE_GENERATE
+#else
+#   define BETTER_ENUMS_DEFAULT_SWITCH_TYPE                                    \
+        BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE
+#   define BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE                           \
+        BETTER_ENUMS_REGULAR_ENUM_SWITCH_TYPE_GENERATE
+#endif
+
+
+
+#ifndef BETTER_ENUMS_DEFAULT_CONSTRUCTOR
+#   define BETTER_ENUMS_DEFAULT_CONSTRUCTOR(Enum)                              \
+      private:                                                                 \
+        Enum() : _value(0) { }
+#endif
+
+
+
+#ifdef BETTER_ENUMS_HAVE_CONSTEXPR
+
+#ifdef BETTER_ENUMS_CONSTEXPR_TO_STRING
+#   define BETTER_ENUMS_DEFAULT_TRIM_STRINGS_ARRAYS                            \
+        BETTER_ENUMS_CXX11_FULL_CONSTEXPR_TRIM_STRINGS_ARRAYS
+#   define BETTER_ENUMS_DEFAULT_TO_STRING_KEYWORD                              \
+        BETTER_ENUMS_CONSTEXPR_TO_STRING_KEYWORD
+#   define BETTER_ENUMS_DEFAULT_DECLARE_INITIALIZE                             \
+        BETTER_ENUMS_DECLARE_EMPTY_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_DEFINE_INITIALIZE                              \
+        BETTER_ENUMS_DO_NOT_DEFINE_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_CALL_INITIALIZE                                \
+        BETTER_ENUMS_DO_NOT_CALL_INITIALIZE
+#else
+#   define BETTER_ENUMS_DEFAULT_TRIM_STRINGS_ARRAYS                            \
+        BETTER_ENUMS_CXX11_PARTIAL_CONSTEXPR_TRIM_STRINGS_ARRAYS
+#   define BETTER_ENUMS_DEFAULT_TO_STRING_KEYWORD                              \
+        BETTER_ENUMS_NO_CONSTEXPR_TO_STRING_KEYWORD
+#   define BETTER_ENUMS_DEFAULT_DECLARE_INITIALIZE                             \
+        BETTER_ENUMS_DO_DECLARE_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_DEFINE_INITIALIZE                              \
+        BETTER_ENUMS_DO_DEFINE_INITIALIZE
+#   define BETTER_ENUMS_DEFAULT_CALL_INITIALIZE                                \
+        BETTER_ENUMS_DO_CALL_INITIALIZE
+#endif
+
+
+
+// Top-level macros.
+
+#define BETTER_ENUM(Enum, Underlying, ...)                                     \
+    BETTER_ENUMS_ID(BETTER_ENUMS_TYPE(                                         \
+        BETTER_ENUMS_CXX11_UNDERLYING_TYPE,                                    \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE,                                      \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE,                             \
+        BETTER_ENUMS_DEFAULT_TRIM_STRINGS_ARRAYS,                              \
+        BETTER_ENUMS_DEFAULT_TO_STRING_KEYWORD,                                \
+        BETTER_ENUMS_DEFAULT_DECLARE_INITIALIZE,                               \
+        BETTER_ENUMS_DEFAULT_DEFINE_INITIALIZE,                                \
+        BETTER_ENUMS_DEFAULT_CALL_INITIALIZE,                                  \
+        Enum, Underlying, __VA_ARGS__))
+
+#define SLOW_ENUM(Enum, Underlying, ...)                                       \
+    BETTER_ENUMS_ID(BETTER_ENUMS_TYPE(                                         \
+        BETTER_ENUMS_CXX11_UNDERLYING_TYPE,                                    \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE,                                      \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE,                             \
+        BETTER_ENUMS_CXX11_FULL_CONSTEXPR_TRIM_STRINGS_ARRAYS,                 \
+        BETTER_ENUMS_CONSTEXPR_TO_STRING_KEYWORD,                              \
+        BETTER_ENUMS_DECLARE_EMPTY_INITIALIZE,                                 \
+        BETTER_ENUMS_DO_NOT_DEFINE_INITIALIZE,                                 \
+        BETTER_ENUMS_DO_NOT_CALL_INITIALIZE,                                   \
+        Enum, Underlying, __VA_ARGS__))
+
+#else
+
+#define BETTER_ENUM(Enum, Underlying, ...)                                     \
+    BETTER_ENUMS_ID(BETTER_ENUMS_TYPE(                                         \
+        BETTER_ENUMS_LEGACY_UNDERLYING_TYPE,                                   \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE,                                      \
+        BETTER_ENUMS_DEFAULT_SWITCH_TYPE_GENERATE,                             \
+        BETTER_ENUMS_CXX98_TRIM_STRINGS_ARRAYS,                                \
+        BETTER_ENUMS_NO_CONSTEXPR_TO_STRING_KEYWORD,                           \
+        BETTER_ENUMS_DO_DECLARE_INITIALIZE,                                    \
+        BETTER_ENUMS_DO_DEFINE_INITIALIZE,                                     \
+        BETTER_ENUMS_DO_CALL_INITIALIZE,                                       \
+        Enum, Underlying, __VA_ARGS__))
+
+#endif
+
+
+
+namespace better_enums {
+
+// Maps.
+
+template <typename T>
+struct map_compare {
+    BETTER_ENUMS_CONSTEXPR_ static bool less(const T& a, const T& b)
+        { return a < b; }
+};
+
+template <>
+struct map_compare<const char*> {
+    BETTER_ENUMS_CONSTEXPR_ static bool less(const char *a, const char *b)
+        { return less_loop(a, b); }
+
+  private:
+    BETTER_ENUMS_CONSTEXPR_ static bool
+    less_loop(const char *a, const char *b, size_t index = 0)
+    {
+        return
+            a[index] != b[index] ? a[index] < b[index] :
+            a[index] == '\0' ? false :
+            less_loop(a, b, index + 1);
+    }
+};
+
+template <>
+struct map_compare<const wchar_t*> {
+    BETTER_ENUMS_CONSTEXPR_ static bool less(const wchar_t *a, const wchar_t *b)
+        { return less_loop(a, b); }
+
+  private:
+    BETTER_ENUMS_CONSTEXPR_ static bool
+    less_loop(const wchar_t *a, const wchar_t *b, size_t index = 0)
+    {
+        return
+            a[index] != b[index] ? a[index] < b[index] :
+            a[index] == L'\0' ? false :
+            less_loop(a, b, index + 1);
+    }
+};
+
+template <typename Enum, typename T, typename Compare = map_compare<T> >
+struct map {
+    typedef T (*function)(Enum);
+
+    BETTER_ENUMS_CONSTEXPR_ explicit map(function f) : _f(f) { }
+
+    BETTER_ENUMS_CONSTEXPR_ T from_enum(Enum value) const { return _f(value); }
+    BETTER_ENUMS_CONSTEXPR_ T operator [](Enum value) const
+        { return _f(value); }
+
+    BETTER_ENUMS_CONSTEXPR_ Enum to_enum(T value) const
+    {
+        return
+            _or_throw(to_enum_nothrow(value), "map::to_enum: invalid argument");
+    }
+
+    BETTER_ENUMS_CONSTEXPR_ optional<Enum>
+    to_enum_nothrow(T value, size_t index = 0) const
+    {
+        return
+            index >= Enum::_size() ? optional<Enum>() :
+            Compare::less(_f(Enum::_values()[index]), value) ||
+            Compare::less(value, _f(Enum::_values()[index])) ?
+                to_enum_nothrow(value, index + 1) :
+            Enum::_values()[index];
+    }
+
+  private:
+    const function      _f;
+};
+
+template <typename Enum, typename T>
+BETTER_ENUMS_CONSTEXPR_ map<Enum, T> make_map(T (*f)(Enum))
+{
+    return map<Enum, T>(f);
+}
+
+}
+
+#define BETTER_ENUMS_DECLARE_STD_HASH(type)                                    \
+    namespace std {                                                            \
+    template <> struct hash<type>                                              \
+    {                                                                          \
+        size_t operator()(const type &x) const                                 \
+        {                                                                      \
+            return std::hash<size_t>()(x._to_integral());                      \
+        }                                                                      \
+    };                                                                         \
+    }
+
+#endif // #ifndef BETTER_ENUMS_ENUM_H

--- a/wrappers/C_CPP/refprop/include/Refprop/fluid_codes.h
+++ b/wrappers/C_CPP/refprop/include/Refprop/fluid_codes.h
@@ -1,0 +1,243 @@
+#pragma once
+#include <enum.h>
+
+/// Reference state
+BETTER_ENUM(RefState, int,
+    DEF,                        /**< Default as specified in fluid file */
+    ASH,                        /**< ASHRAE convention */
+    NBP,                        /**< Normal boiling point(s) */
+    IIR,                        /**< IIR convention */
+    OTH,                        /**< Other, as specifed for real gas state */
+    OT0,                        /**< Other, as specified for ideal-gas state */
+    NA                          /**< Not applicable, results in random reference state */
+)
+
+/// Unit system
+BETTER_ENUM(Units, int,
+    DEFAULT,
+    MOLE_SI,
+    MASS_SI,
+    SI_WITH_C,
+    MOLAR_BASE_SI,
+    MASS_BASE_SI,
+    ENGLISH,
+    MOLAR_ENGLISH,
+    MKS,
+    CGS,
+    MIXED,
+    MEUNITS,
+    USER
+)
+
+/// Basis for composition fractions
+BETTER_ENUM(Basis, int,
+    MOLAR = 0,
+    MASS = 1
+)
+
+/// Properties
+BETTER_ENUM(Prop, int,
+    T,
+    P,
+    D,
+    V,
+    E,
+    H,
+    S,
+    CV,
+    CP,
+    CPCV,
+    W,
+    Z,
+    JT,
+    A,
+    G,
+    R,
+    M,
+    QMASS,
+    QMOLE
+)
+
+/// Flag for RefpropLib
+BETTER_ENUM(FlagRefpropLib, int,
+    NONE = 0,                   /**< Do nothing extra */
+    CALL_SATSPLN = 1            /**< Call the SATSPLN routine */
+)
+
+/// Flag for AllPropsLib
+BETTER_ENUM(FlagAllPropsLib, int,
+    WRITE_NO_UNITS = 0,         /**< Write nothing to hUnitsArray (better performance) */
+    WRITE_UNITS_W_LABEL = 1,    /**< Write labels and units to hUnitsArray */
+    WRITE_UNITS_W_NUMBER = 2,   /**< Write iUCodeArray string number and units (no props calculated) */
+    WRITE_FIRST_UNIT = -1       /**< Write labels and units for only first item */
+)
+
+/**
+ * @brief Flags for AbflshLib
+ *
+ * Example integer representation:
+ *  RETURN_LOWER_DENSITY and DETERMINE_PHASE and ALL_MASS = 301
+ */
+namespace FlagAbflshLib {
+    BETTER_ENUM(Basis, int,
+        ALL_MOLAR = 0,
+        ALL_MASS = 1,
+        MASS_EXCEPT_COMPOSITION = 2
+    )
+
+    BETTER_ENUM(Phase, int,
+        DETERMINE_PHASE = 0,
+        KNOWN_LIQUID = 1,
+        KNOWN_VAPOR = 2,
+        KNOWN_TWO_PHASE = 3
+    )
+
+    BETTER_ENUM(Quality, int,
+        DEFAULT = 0,
+        MOLAR_BASIS = 1,
+        MASS_BASIS = 2,
+        RETURN_LOWER_DENSITY = 3,
+        RETURN_HIGHER_DENSITY = 4
+    )
+}
+
+/// Flags for FlagsLib (general program behavior)
+namespace FlagFlagsLib {
+    BETTER_ENUM(Return_errors, int,
+        ONLY_FINAL = 0,
+        ALL_INTERMEDIATE = 1,
+        NONE = 2,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Write_errors, int,
+        NO_WRITE = 0,
+        WRITE = -1,
+        IF_POS_ERR = 1,
+        AND_PAUSE = -3,
+        IF_POS_ERR_AND_PAUSE = 3,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Dir_search, int,
+        SEARCH_OTHERS = 0,
+        NO_SEARCH = 1,
+        ONE_ATTEMPT = 2,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Cp0Ph0, int,
+        CP0_IDEAL_GAS_EQ = 1,
+        PH0_IDEAL_GAS_EQ = 2,
+        get_value = -999
+    )
+
+    BETTER_ENUM(PX0, int,
+        FILE_IDEAL_GAS_EQ = 0,
+        PX0_AND_NO_SETREF = 1,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Skip_SETREF, int,
+        CALL_SETREF = 0,
+        SKIP_SETREF = 1,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Mixture_reference, int,
+        DO_NOTHING = 0,
+        CALL_SETREF = 2,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Skip_ECS, int,
+        LOAD_ECS = 0,
+        SKIP_ECS = 1,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Splines_off, int,
+        SPLINES_OFF = 1,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Bounds, int,
+        CHECK_BOUNDS = 0,
+        IGNORE_BOUNDS = 1,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Cache, int,
+        ALL_CALCULATED = 0,
+        ONLY_LOW_LEVEL = 1,
+        ONLY_MAJOR = 2,
+        NO_CACHE = 3,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Reset_all, int,
+        RESET_ALL_CACHED = 2,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Reset_HMX, int,
+        REREAD_HMX = 1,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Pure_fluid, int,
+        USE_MIXTURE_EOS = 0,
+        USE_PURE_FLUID = 1,
+        get_value = -999
+    )
+
+    // TODO: implement a function for "Component number"
+    //BETTER_ENUM(Component_number, int,
+    //)
+
+    BETTER_ENUM(PR, int,
+        NO_PENG_ROBINSON = 0,
+        USE_PENG_ROBINSON = 2,
+        PENG_ROBINSON_NO_TRANS_TERM = 3,
+        get_value = -999
+    )
+
+    BETTER_ENUM(kij_Zero, int,
+        USE_FITTED = 0,
+        USE_ESTIMATED = 1,
+        SET_TO_ZERO = 2,
+        get_value = -999
+    )
+
+    BETTER_ENUM(AGA8, int,
+        TURN_OFF = 0,
+        TURN_ON = 1,
+        get_value = -999
+    )
+
+    BETTER_ENUM(GERG, int,
+        TURN_OFF = 0,
+        TURN_ON = 1,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Gas_constant, int,
+        CURRENT_WITH_EXCEPTIONS = 0,
+        CURRENT_FOR_ALL = 1,
+        FROM_FLUID_FILES = 2,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Calorie, int,
+        CAL_PER_J_4_184 = 0,
+        CAL_PER_J_4_1868 = 1,
+        get_value = -999
+    )
+
+    BETTER_ENUM(Debug, int,
+        NO_DEBUG = 0,
+        INPUTS_OUTPUTS = 1,
+        FILES_ACCESSED = 2,
+        get_value = -999
+    )
+}

--- a/wrappers/C_CPP/refprop/include/Refprop/refprop_v10.h
+++ b/wrappers/C_CPP/refprop/include/Refprop/refprop_v10.h
@@ -1,0 +1,103 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <map>
+#include "manyso/native.h"
+#include "REFPROP_lib.h"
+#include "fluid_codes.h"
+#include "enum.h"
+#include "utils.h"
+
+// Macro to cast a string to a const char*
+#define STR_TO_CHAR(hrf) const_cast<char*>(hrf.c_str())
+
+// Constants for C calls
+const int kHerrLength = 255;                        // length of output error strings
+const int kHunitsLength = 255;                      // length of output units
+const int kHunitsArrayLength = 10000;               // length of output units array
+const int kNumComp = 20;                            // max number of compositions in liquid or vapor phase
+const int kNumOutputs = 200;                        // max number of output property values
+const double kNothingCalculated = -9999990;         // value representing that nothing was calculated
+const double kErrorOccurred = -9999970;             // value representing that an error occurred
+
+class RefpropV10 {
+public:
+    RefpropV10();
+
+    RefpropV10(const std::string& abs_path_dll);
+
+    // Add many methods via variadic functions, each corresponding to a 1-to-1 wrapper of a function from the shared library (credit: manyso)
+    #define X(name) template<class ...Args> void name(Args&&... args){ return lib_wrap_->getAddress<name ## _POINTER>(#name)(std::forward<Args>(args)...); };
+        LIST_OF_REFPROP_FUNCTION_NAMES
+    #undef X
+
+    struct FluidData {
+        int n_components;
+        std::string fluid_files;
+        std::string mixture_files;
+        RefState ref_state;
+
+        FluidData() : n_components(0), fluid_files(""), mixture_files(""), ref_state(RefState::_from_index(0)) {}
+    };
+
+    struct LibInputs {
+        std::string hFld;
+        std::string hIn;
+        std::string hOut;
+        Units iUnits;
+        Basis iMass;
+        int iFlag;
+        double a;
+        double b;
+        std::vector<double> z;
+
+        LibInputs() : hFld(""), hIn(""), hOut(""), iUnits(Units::_from_index(0)), iMass(Basis::_from_index(0)),
+            iFlag(-1), a(NaN<double>), b(NaN<double>), z({}) {}
+    };
+
+    struct LibOutputs {
+        std::string output_props;
+        std::vector<double> Output;
+        std::string hUnits;
+        int iUCode;
+        std::vector<int> iUCodeArray;
+        double T;
+        double P;
+        double D;
+        double Dl;
+        double Dv;
+        std::vector<double> x;
+        std::vector<double> y;
+        std::vector<double> x3;
+        double q;
+        double e;
+        double h;
+        double s;
+        double Cv;
+        double Cp;
+        double w;
+        int ierr;
+        std::string herr;
+
+        LibOutputs() : Output({}), hUnits(""), iUCode(-1), iUCodeArray({}), T(NaN<double>), P(NaN<double>), D(NaN<double>),
+            Dl(NaN<double>), Dv(NaN<double>), x({}), y({}), x3({}), q(NaN<double>), e(NaN<double>),
+            h(NaN<double>), s(NaN<double>), Cv(NaN<double>), Cp(NaN<double>), w(NaN<double>), ierr(-1), herr("") {}
+    };
+
+    RefpropV10::LibOutputs RefpropLib(RefpropV10::LibInputs inputs);
+    RefpropV10::LibOutputs AbflshLib(RefpropV10::LibInputs inputs);
+    RefpropV10::LibOutputs AllPropsLib(RefpropV10::LibInputs inputs);
+    int FlagsLib(std::string option, int command=-999);
+    int GetEnumLib(std::string units);
+    int SetFluidsLib(const std::string& fluid_names);
+    int SetupLib(const FluidData& fluid_data);
+
+private:
+    const AbstractSharedLibraryWrapper::load_method kLoadMethod_ = AbstractSharedLibraryWrapper::load_method::FROM_FILE;
+    std::unique_ptr<NativeSharedLibraryWrapper> lib_wrap_;
+    std::string abs_path_dll_;                         // path and file name
+};
+
+std::string ConstructErrorMessage(int error_code, const char* error_message);
+
+std::map<std::string, double> IndexVectorByLabels(const std::vector<double>& values, const std::string& labels);

--- a/wrappers/C_CPP/refprop/include/Refprop/refprop_v10.h
+++ b/wrappers/C_CPP/refprop/include/Refprop/refprop_v10.h
@@ -11,20 +11,9 @@
 // Macro to cast a string to a const char*
 #define STR_TO_CHAR(hrf) const_cast<char*>(hrf.c_str())
 
-// Constants for C calls
-const int kHerrLength = 255;                        // length of output error strings
-const int kHunitsLength = 255;                      // length of output units
-const int kHunitsArrayLength = 10000;               // length of output units array
-const int kNumComp = 20;                            // max number of compositions in liquid or vapor phase
-const int kNumOutputs = 200;                        // max number of output property values
-const double kNothingCalculated = -9999990;         // value representing that nothing was calculated
-const double kErrorOccurred = -9999970;             // value representing that an error occurred
-
 class RefpropV10 {
 public:
     RefpropV10();
-
-    RefpropV10(const std::string& abs_path_dll);
 
     // Add many methods via variadic functions, each corresponding to a 1-to-1 wrapper of a function from the shared library (credit: manyso)
     #define X(name) template<class ...Args> void name(Args&&... args){ return lib_wrap_->getAddress<name ## _POINTER>(#name)(std::forward<Args>(args)...); };

--- a/wrappers/C_CPP/refprop/include/Refprop/utils.h
+++ b/wrappers/C_CPP/refprop/include/Refprop/utils.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <string>
+#include <limits>
 
 template<typename T>
 constexpr T NaN = std::numeric_limits<T>::quiet_NaN();      // simplify quiet_NaN()

--- a/wrappers/C_CPP/refprop/include/Refprop/utils.h
+++ b/wrappers/C_CPP/refprop/include/Refprop/utils.h
@@ -1,0 +1,15 @@
+#pragma once
+
+template<typename T>
+constexpr T NaN = std::numeric_limits<T>::quiet_NaN();      // simplify quiet_NaN()
+
+template<typename T>
+constexpr T inf = std::numeric_limits<T>::infinity();       // simplify infinity()
+
+bool file_exists(const std::string& filename);
+
+std::string parent_path(const std::string& filename);
+
+std::string StripTrailingWhiteSpace(std::string str);
+
+std::string StripTrailingWhiteSpaceAndPipes(std::string str);

--- a/wrappers/C_CPP/refprop/src/refprop_v10.cpp
+++ b/wrappers/C_CPP/refprop/src/refprop_v10.cpp
@@ -1,0 +1,376 @@
+#define REFPROP_IMPLEMENTATION                              // only include in one file and not the header
+#include <vector>
+#include <string>
+#include <map>
+#include <algorithm>
+#include "refprop_v10.h"
+#include "utils.h"
+
+const std::string kAbsPathDll = REFPROP10_PATH;             // output from build system
+
+RefpropV10::RefpropV10() : RefpropV10(kAbsPathDll) {}
+
+RefpropV10::RefpropV10(const std::string &abs_path_dll)
+    : abs_path_dll_(abs_path_dll)
+{
+    if (!file_exists(abs_path_dll_)) {
+        throw std::runtime_error("REFPROP version 10 library path does not point to a file.");
+    }
+    std::replace(abs_path_dll_.begin(), abs_path_dll_.end(), '\\', '/');    // include only '/' in file path
+    
+    // Wrap refprop library via manyso to manage memory
+    lib_wrap_ = std::make_unique<NativeSharedLibraryWrapper>(abs_path_dll_, kLoadMethod_);
+
+    // Set path to fluid data
+    std::string dll_path_string = parent_path(abs_path_dll_);
+    this->SETPATHdll(
+        STR_TO_CHAR(dll_path_string),
+        dll_path_string.length() + 1
+    );
+}
+
+RefpropV10::LibOutputs RefpropV10::RefpropLib(RefpropV10::LibInputs inputs) {
+    // NOTE: passing inputs by value as library expects non-const references
+
+    // Strip const-ness of input conversions
+    int iUnits = GetEnumLib(inputs.iUnits._to_string());
+    int iMass = inputs.iMass._to_integral();
+
+    // Declare outputs
+    double Output[kNumOutputs];                             // array of properties
+    char hUnits[kHunitsLength];                             // units for first property in Output
+    int iUCode = -1;                                        // units of the first property in Output
+    double x[kNumComp];                                     // composition of the liquid phase of each component
+    double y[kNumComp];                                     // composition of the vapor phase of each component
+    double x3[kNumComp];                                    // composition of a second liquid phase of each component
+    double q = NaN<double>;                                 // vapor quality
+    int ierr = -1;                                          // error flag
+    char herr[kHerrLength];                                 // error string
+
+    // Initialize the above C-style array outputs
+    std::fill_n(Output, kNumOutputs, NaN<double>);
+    std::fill_n(hUnits, kHunitsLength, '\0');
+    std::fill_n(x, kNumComp, NaN<double>);
+    std::fill_n(y, kNumComp, NaN<double>);
+    std::fill_n(x3, kNumComp, NaN<double>);
+    std::fill_n(herr, kHerrLength, '\0');
+
+    // Call subroutine
+    this->REFPROPdll(
+        STR_TO_CHAR(inputs.hFld),                           // hFld
+        STR_TO_CHAR(inputs.hIn),                            // hIn
+        STR_TO_CHAR(inputs.hOut),                           // hOut
+        iUnits,                                             // iUnits
+        iMass,                                              // iMass
+        inputs.iFlag,                                       // iFlag
+        inputs.a,                                           // a
+        inputs.b,                                           // b
+        inputs.z.data(),                                    // z
+        Output,                                             // Output
+        hUnits,                                             // hUnits
+        iUCode,                                             // iUCode
+        x,                                                  // x
+        y,                                                  // y
+        x3,                                                 // x3
+        q,                                                  // q
+        ierr,                                               // ierr
+        herr,                                               // herr
+        inputs.hFld.length() + 1,                           // hFld_length, add one for null terminator character
+        inputs.hIn.length() + 1,                            // hIn_length
+        inputs.hOut.length() + 1,                           // hOut_length
+        kHunitsLength,                                      // hUnits_length
+        kHerrLength                                         // herr_length
+    );
+
+    std::string error = StripTrailingWhiteSpace(std::string(herr));
+    if (ierr > 0) printf("Error calling subroutine: %d. Message: %s\n", ierr, error.c_str());
+
+    // Cleanly format 'Output' values
+    std::vector<double> output(std::begin(Output), std::end(Output));                       // convert Output array to vector
+    while (!output.empty() && output.back() == kNothingCalculated) { output.pop_back(); }   // remove trailing not-calculated values
+    std::replace(output.begin(), output.end(), kNothingCalculated, NaN<double>);            // replace other 'not-calculated' with NaN
+    std::replace(output.begin(), output.end(), kErrorOccurred, -inf<double>);               // replace error values with -infinity
+
+    // Populate output structure
+    RefpropV10::LibOutputs outputs;
+    outputs.output_props = inputs.hOut;
+    outputs.Output = output;
+    outputs.hUnits = StripTrailingWhiteSpace(std::string(hUnits));                          // strip trailing spaces
+    outputs.iUCode = iUCode;
+    int n_components = inputs.z.size();                                                     // output for actual number of components
+    outputs.x.assign(std::begin(x), std::begin(x) + n_components);
+    outputs.y.assign(std::begin(y), std::begin(y) + n_components);
+    outputs.x3.assign(std::begin(x3), std::begin(x3) + n_components);
+    outputs.q = q;
+    outputs.ierr = ierr;
+    outputs.herr = error;
+
+    return outputs;
+}
+
+RefpropV10::LibOutputs RefpropV10::AbflshLib(RefpropV10::LibInputs inputs)
+{
+    // NOTE: passing inputs by value as library expects non-const references
+    // TODO: combine enum flags
+    
+    // Declare outputs
+    double T = NaN<double>;                                 // [K] temperature
+    double P = NaN<double>;                                 // [kPa] pressure
+    double D = NaN<double>;                                 // [mol/L or kg/m3] density
+    double Dl = NaN<double>;                                // [mol/L or kg/m3] density of the liquid phase
+    double Dv = NaN<double>;                                // [mol/L or kg/m3] density of the vapor phase
+    double x[kNumComp];                                     // composition of the liquid phase of each component
+    double y[kNumComp];                                     // composition of the vapor phase of each component
+    double q = NaN<double>;                                 // vapor quality on a molar basis
+    double e = NaN<double>;                                 // [J/mol or kJ/kg] internal energy
+    double h = NaN<double>;                                 // [J/mol or kJ/kg] enthalpy
+    double s = NaN<double>;                                 // [J/mol-K or kJ/kg-K] entropy
+    double Cv = NaN<double>;                                // [J/mol-K or kJ/kg-K] isochoric heat capacity
+    double Cp = NaN<double>;                                // [J/mol-K or kJ/kg-K] isobaric heat capacity
+    double w = NaN<double>;                                 // [m/s] speed of sound
+    int ierr = -1;                                          // error flag
+    char herr[kHerrLength];                                 // error string
+
+    // Initialize the above C-style array outputs
+    std::fill_n(x, kNumComp, NaN<double>);
+    std::fill_n(y, kNumComp, NaN<double>);
+    std::fill_n(herr, kHerrLength, '\0');
+
+    // Call subroutine
+    this->ABFLSHdll(
+        STR_TO_CHAR(inputs.hIn),                            // ab
+        inputs.a,                                           // a
+        inputs.b,                                           // b
+        inputs.z.data(),                                    // z
+        inputs.iFlag,                                       // iFlag
+        T,
+        P,
+        D,
+        Dl,
+        Dv,
+        x,
+        y,
+        q,
+        e,
+        h,
+        s,
+        Cv,
+        Cp,
+        w,
+        ierr,
+        herr,
+        inputs.hIn.length() + 1,                            // ab_length
+        kHerrLength                                         // herr_length
+    );
+
+    std::string error = StripTrailingWhiteSpace(std::string(herr));
+    if (ierr > 0) printf("Error calling subroutine: %d. Message: %s\n", ierr, error.c_str());
+
+    // Populate output structure
+    RefpropV10::LibOutputs outputs;
+    outputs.output_props = "T;P;D;Dl;Dv;q;e;h;s;Cv;Cp;w";
+    outputs.Output = {T, P, D, Dl, Dv, q, e, h, s, Cv, Cp, w};
+    int n_components = inputs.z.size();                                             // output for actual number of components
+    outputs.T = T;
+    outputs.P = P;
+    outputs.D = D;
+    outputs.Dl = Dl;
+    outputs.Dv = Dv;
+    outputs.x.assign(std::begin(x), std::begin(x) + n_components);
+    outputs.y.assign(std::begin(y), std::begin(y) + n_components);
+    outputs.q = q;                                                                  // molar basis
+    outputs.e = e;
+    outputs.h = h;
+    outputs.s = s;
+    outputs.Cv = Cv;
+    outputs.Cp = Cp;
+    outputs.w = w;
+    outputs.ierr = ierr;
+    outputs.herr = error;
+    
+    return outputs;
+}
+
+RefpropV10::LibOutputs RefpropV10::AllPropsLib(RefpropV10::LibInputs inputs)
+{
+    // NOTE: passing inputs by value as library expects non-const references
+
+    // Strip const-ness of input conversions
+    int units = GetEnumLib(inputs.iUnits._to_string());
+    int basis = inputs.iMass._to_integral();
+
+    // Declare outputs
+    double Output[kNumOutputs];                             // array of properties
+    char hUnitsArray[kHunitsArrayLength];                   // units for properties in Output
+    int iUCodeArray[kNumOutputs];                           // units of the properties in Output
+    int ierr = -1;                                          // error flag
+    char herr[kHerrLength];                                 // error string
+
+    // Initialize the above C-style array outputs
+    std::fill_n(Output, kNumOutputs, NaN<double>);
+    std::fill_n(hUnitsArray, kHunitsArrayLength, '\0');
+    std::fill_n(iUCodeArray, kNumOutputs, -1);
+    std::fill_n(herr, kHerrLength, '\0');
+
+    // Call subroutine
+    this->ALLPROPSdll(
+        STR_TO_CHAR(inputs.hOut),                           // hOut
+        units,                                              // iUnits
+        basis,                                              // iMass
+        inputs.iFlag,                                       // iFlag
+        inputs.a,                                           // T
+        inputs.b,                                           // D
+        inputs.z.data(),                                    // z
+        Output,                                             // Output
+        hUnitsArray,                                        // hUnits
+        iUCodeArray,                                        // iUCode
+        ierr,                                               // ierr
+        herr,                                               // herr
+        inputs.hOut.length() + 1,                           // hOut_length
+        kHunitsArrayLength,                                 // hUnitsArray_length
+        kHerrLength                                         // herr_length
+    );
+
+    // Cleanly format 'Output' values
+    std::vector<double> output(std::begin(Output), std::end(Output));                       // convert output array to vector
+    while (!output.empty() && output.back() == kNothingCalculated) { output.pop_back(); }   // remove trailing not-calculated values
+    std::replace(output.begin(), output.end(), kNothingCalculated, NaN<double>);            // replace other 'not-calculated' with NaN
+    std::replace(output.begin(), output.end(), kErrorOccurred, -inf<double>);               // replace error values with -infinity
+
+    // Populate output structure
+    RefpropV10::LibOutputs outputs;
+    outputs.output_props = inputs.hOut;
+    outputs.Output = output;
+    outputs.hUnits = StripTrailingWhiteSpaceAndPipes(std::string(hUnitsArray));
+    outputs.iUCodeArray.assign(std::begin(iUCodeArray), std::begin(iUCodeArray) + output.size());
+    outputs.ierr = ierr;
+    outputs.herr = StripTrailingWhiteSpace(std::string(herr));
+
+    return outputs;
+}
+
+int RefpropV10::GetEnumLib(std::string units)
+{
+    // Set flag to specify type of enumerated value to return
+    int iFlag = 0;                                          // 0 = check all strings possible
+
+    // Replace any underscores (which the enums have) to spaces
+    std::replace(units.begin(), units.end(), '_', ' ');
+
+    // Declare outputs and initialize
+    int iEnum = -1;
+    int ierr = -1;
+    char herr[kHerrLength];
+    std::fill_n(herr, kHerrLength, '\0');
+
+    // Call subroutine
+    this->GETENUMdll(
+        iFlag,                                              // type of enumerated value to return
+        STR_TO_CHAR(units),                                 // hEnum, string representation of the enum to return
+        iEnum,                                              // the enum that is returned
+        ierr,
+        herr,
+        units.length() + 1,
+        kHerrLength
+    );
+
+    std::string error = StripTrailingWhiteSpace(std::string(herr));
+    if (ierr > 0) printf("Error calling subroutine: %d. Message: %s\n", ierr, error.c_str());
+
+    return iEnum;
+}
+
+int RefpropV10::FlagsLib(std::string option, int command)
+{
+    // Declare outputs and initialize
+    int setting = -1;
+    int ierr = -1;
+    char herr[kHerrLength];
+    std::fill_n(herr, kHerrLength, '\0');
+
+    // Replace any underscores in option name with spaces
+    std::replace(option.begin(), option.end(), '_', ' ');
+
+    // Call subroutine
+    this->FLAGSdll(
+        STR_TO_CHAR(option),                                // hFlag, indicator for the option to set
+        command,                                            // jFlag, command for the option
+        setting,                                            // kFlag, current setting of the option
+        ierr,
+        herr,
+        option.length() + 1,
+        kHerrLength
+    );
+
+    std::string error = StripTrailingWhiteSpace(std::string(herr));
+    if (ierr > 0) printf("Error calling subroutine: %d. Message: %s\n", ierr, error.c_str());
+
+    return setting;
+}
+
+int RefpropV10::SetFluidsLib(const std::string& fluid_names)
+{
+    int ierr = -1;
+    
+    // Call subroutine
+    this->SETFLUIDSdll(
+        STR_TO_CHAR(fluid_names),                           // hFld
+        ierr,
+        fluid_names.length() + 1
+    );
+
+    return ierr;
+}
+
+int RefpropV10::SetupLib(const FluidData& fluid_data) {
+    // TODO: verify fluid files exist using filesystem
+
+    // Parameters:
+    int ncomp = fluid_data.n_components;                    // number of components
+    std::string hFiles = fluid_data.fluid_files;            // array of file names
+    std::string hFmix = fluid_data.mixture_files;           // mixture coefficient file name
+    std::string hrf = fluid_data.ref_state._to_string();    // reference state
+
+    // Outputs:
+    int ierr = 0;                                           // error flag
+    char herr[kHerrLength];                                 // error string
+
+    this->SETUPdll(
+        ncomp,
+        STR_TO_CHAR(hFiles),
+        STR_TO_CHAR(hFmix),
+        STR_TO_CHAR(hrf),
+        ierr,
+        herr,
+        hFiles.length() + 1,                                // add one for null terminator character
+        hFmix.length() + 1,
+        hrf.length() + 1,
+        kHerrLength
+    );
+
+    if (ierr != 0) {
+        throw std::runtime_error(ConstructErrorMessage(ierr, herr));
+    }
+
+    return ierr;
+}
+
+std::string ConstructErrorMessage(int errorCode, const char* errorMessage) {
+    std::stringstream ss;
+    ss << "Error code: " << errorCode << ". Error message: " << errorMessage;
+    return ss.str();
+}
+
+std::map<std::string, double> IndexVectorByLabels(const std::vector<double>& values, const std::string& labels) {
+    std::map<std::string, double> result;
+    std::istringstream label_stream(labels);
+    std::string label;
+
+    for (const double& value : values) {
+        if (std::getline(label_stream, label, ';')) {
+            result[label] = value;
+        }
+    }
+
+    return result;
+}

--- a/wrappers/C_CPP/refprop/src/utils.cpp
+++ b/wrappers/C_CPP/refprop/src/utils.cpp
@@ -1,0 +1,38 @@
+#include <string>
+#include <fstream>
+#include "utils.h"
+
+bool file_exists(const std::string& filepath) {
+    std::ifstream file(filepath);
+    return file.good();
+}
+
+std::string parent_path(const std::string& filepath) {
+    size_t pos = filepath.find_last_of("/\\");          // find last occurrence of a path separator
+    if (pos != std::string::npos) {
+        return filepath.substr(0, pos);
+    }
+    return "";                                          // return empty string if there's no parent path
+}
+
+std::string StripTrailingWhiteSpace(std::string str) {
+    size_t pos = str.find_last_not_of(" \t\n\r\f\v");   // find last non-whitespace character
+    if (pos != std::string::npos) {
+        str.erase(pos + 1);                             // erase trailing whitespace
+    }
+    else {
+        str.clear();                                    // clear string if all whitespace
+    }
+    return str;
+}
+
+std::string StripTrailingWhiteSpaceAndPipes(std::string str) {
+    size_t pos = str.find_last_not_of(" |\t\n\r\f\v");   // find last non-whitespace/pipe character
+    if (pos != std::string::npos) {
+        str.erase(pos + 1);                             // erase trailing whitespace
+    }
+    else {
+        str.clear();                                    // clear string if all whitespace
+    }
+    return str;
+}

--- a/wrappers/C_CPP/src/main.cpp
+++ b/wrappers/C_CPP/src/main.cpp
@@ -1,0 +1,126 @@
+#include "test_utils.h"
+#include "refprop_v10.h"
+#include "fluid_codes.h"
+
+void TestGetEnumLib() {
+    // Instantiate Refprop
+    RefpropV10 refpropv10;
+
+    // Call function and test outputs
+    EXPECT_EQ(0, refpropv10.GetEnumLib("DEFAULT"));
+    //EXPECT_EQ(-9999970, refpropv10.GetEnumLib("MOLE SI"));      // MOLE SI is currently not recognized
+    EXPECT_EQ(2, refpropv10.GetEnumLib("MASS SI"));
+    EXPECT_EQ(3, refpropv10.GetEnumLib("SI WITH C"));
+    EXPECT_EQ(20, refpropv10.GetEnumLib("MOLAR BASE SI"));
+    EXPECT_EQ(21, refpropv10.GetEnumLib("MASS BASE SI"));
+    EXPECT_EQ(5, refpropv10.GetEnumLib("ENGLISH"));
+    EXPECT_EQ(6, refpropv10.GetEnumLib("MOLAR ENGLISH"));
+    EXPECT_EQ(7, refpropv10.GetEnumLib("MKS"));
+    EXPECT_EQ(8, refpropv10.GetEnumLib("CGS"));
+    EXPECT_EQ(9, refpropv10.GetEnumLib("MIXED"));
+    EXPECT_EQ(10, refpropv10.GetEnumLib("MEUNITS"));
+    EXPECT_EQ(11, refpropv10.GetEnumLib("USER"));
+}
+
+void TestSetFluidsLib() {
+    const int SUCCESS = 0;
+    
+    // Instantiate Refprop
+    RefpropV10 refpropv10;
+
+    // Call function and test for success
+    EXPECT_EQ(SUCCESS, refpropv10.SetFluidsLib("ARGON"));
+    EXPECT_EQ(SUCCESS, refpropv10.SetFluidsLib("ARGON; NITROGEN"));
+    EXPECT_NE(SUCCESS, refpropv10.SetFluidsLib("NOT_A_FLUID_NAME"));
+}
+
+void TestAbflshLib() {
+    const double kRelTol = 0.001;    // 0.001 == 0.1 %
+
+    // Instantiate Refprop
+    RefpropV10 refpropv10;
+
+    // Set fluid
+    refpropv10.SetFluidsLib("NITROGEN;OXYGEN");
+
+    // Define inputs
+    RefpropV10::LibInputs inputs;
+    inputs.hIn = "TP";
+    inputs.a = 293;
+    inputs.b = 101.325;
+    inputs.z = { 0.5, 0.5 };
+    inputs.iFlag = 0;
+
+    // Call AbflshLib using inputs
+    RefpropV10::LibOutputs outputs = refpropv10.AbflshLib(inputs);
+
+    // Map outputs
+    std::map<std::string, double> output_map = IndexVectorByLabels(outputs.Output, outputs.output_props);
+
+    // Test outputs
+    EXPECT_NEAR_REL(8516.9320996925780, output_map["h"], kRelTol);
+}
+
+void TestAllPropsLib() {
+    const double kRelTol = 0.001;    // 0.001 == 0.1 %
+
+    // Instantiate Refprop
+    RefpropV10 refpropv10;
+
+    // Set fluid
+    int result = refpropv10.SetFluidsLib("NITROGEN;OXYGEN");
+
+    // Define inputs
+    RefpropV10::LibInputs inputs;
+    inputs.hOut = "H;S";
+    inputs.iUnits = Units::MOLAR_BASE_SI;
+    inputs.iMass = Basis::MOLAR;
+    inputs.iFlag = FlagAllPropsLib::WRITE_NO_UNITS;
+    inputs.a = 293.;              // T [K]
+    inputs.b = 41.613;            // D [mol/m3]
+    inputs.z = { 0.5, 0.5 };
+
+    // Call AllPropsLib using inputs
+    RefpropV10::LibOutputs outputs = refpropv10.AllPropsLib(inputs);
+
+    // Map and test outputs
+    std::map<std::string, double> output_map = IndexVectorByLabels(outputs.Output, outputs.output_props);
+    EXPECT_NEAR_REL(8516.9320480273145, output_map["H"], kRelTol);
+}
+
+void TestRefpropLib() {
+    const double kRelTol = 0.001;    // 0.001 == 0.1 %
+
+    // Instantiate Refprop
+    RefpropV10 refpropv10;
+
+    // Define inputs
+    RefpropV10::LibInputs inputs;
+    inputs.hFld = "WATER";
+    inputs.hIn = "PQ";
+    inputs.hOut = "T";
+    inputs.iUnits = Units::DEFAULT;
+    inputs.iMass = Basis::MOLAR;
+    inputs.iFlag = FlagRefpropLib::NONE;
+    inputs.a = 101.325;
+    inputs.b = 0.;
+    inputs.z = { 20., 0. };
+
+    // Call Refprop using inputs
+    RefpropV10::LibOutputs outputs = refpropv10.RefpropLib(inputs);
+
+    // Map and test outputs
+    std::map<std::string, double> output_map = IndexVectorByLabels(outputs.Output, outputs.output_props);
+    EXPECT_NEAR_REL(373.1242958477, output_map["T"], kRelTol);
+}
+
+int main() {
+    TestGetEnumLib();
+    TestSetFluidsLib();
+    TestAbflshLib();
+    TestAllPropsLib();
+    TestRefpropLib();
+
+    std::cout << "Tests finished." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
This is an updated but simple C++ wrapper for REFPROP v10.
- Minimum compatibility is with C++11.
- Utilizes manyso for memory safety.
- Includes a CMake build specification for simple deployment.
- Has only been tested with Windows, but Linux and macOS will follow. 