### PR TITLE
Patch Mathematica wrapper (RefpropLink) to better locate NIST REFPROP DLL

### DIFF
--- a/wrappers/Mathematica/README.md
+++ b/wrappers/Mathematica/README.md
@@ -24,7 +24,10 @@ This instructions file is extremely useful for initial installation and providin
 
 ## Prerequisites (v1.1)
 
-   - **NIST REFPROP** 9.1 or later **_must_** be installed to make use of the wrapper functions provided here.  However, **NIST REFPROP 10.x** is recommended.  See [NIST.gov](https://www.nist.gov/srd/refprop) for licensing.  
+   - **NIST REFPROP** 9.1 or later **_must_** be installed to make use of the wrapper functions provided here.  However, **NIST REFPROP 10.x** is recommended.  See [NIST.gov](https://www.nist.gov/srd/refprop) for licensing.  REFPROP should be installed either:
+       1. In the default location `C:\Program Files(x86)\REFPROP`,
+       2. In a location specified by the `RPprefix` environment variable, or
+       3. In a location selected using the `SetDLL[]` function.
 
    - **Mathematica 13.x** is required to build and install using the new Paclet and Documentation Tools introduced in Mathematica 13.0.  Doe to some early release issues, **Mathematica 13.2** or greater is recommended for the most complete formatting and indexing of the RefpropLink documentation pages to the Wolfram Documentation Center standards.  
 

--- a/wrappers/Mathematica/RefpropLink/Documentation/English/ReferencePages/Symbols/SetDLL.nb
+++ b/wrappers/Mathematica/RefpropLink/Documentation/English/ReferencePages/Symbols/SetDLL.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     65074,       1378]
-NotebookOptionsPosition[     55736,       1188]
-NotebookOutlinePosition[     56522,       1214]
-CellTagsIndexPosition[     56442,       1209]
+NotebookDataLength[     65448,       1384]
+NotebookOptionsPosition[     56109,       1194]
+NotebookOutlinePosition[     56895,       1220]
+CellTagsIndexPosition[     56815,       1215]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -52,10 +52,15 @@ this session; but ",
  Cell[BoxData[
   StyleBox["permSet", "TI"]], "InlineFormula",ExpressionUUID->
   "47798511-e736-4dd6-a617-2b28534006f8"],
- " = 1+ will save the setting for future sessions."
+ " = 1+ will save the setting for future sessions.  Passing  ",
+ Cell[BoxData[
+  StyleBox["permSet", "TI"]], "InlineFormula",ExpressionUUID->
+  "dae5b460-b15e-e644-a1da-f914d0ba8f0d"],
+ " = -1 will simply return the currently set DLL path."
 }], "Usage",
- CellChangeTimes->{{3.885040984992326*^9, 3.8850409852764883`*^9}, {
-  3.8851436316337595`*^9, 3.885143645158799*^9}},
+ CellChangeTimes->{{3.885040984992326*^9, 3.885040985276488*^9}, {
+  3.885143631633759*^9, 3.885143645158799*^9}, {3.9204330841751766`*^9, 
+  3.9204330887520046`*^9}, {3.9204331193878517`*^9, 3.920433184368679*^9}},
  CellID->141853299,ExpressionUUID->"a01abdac-8616-43c7-8d5f-40b9fc5bce22"],
 
 Cell[TextData[{
@@ -70,19 +75,19 @@ directory for its 64-bit dynamic link library (",
  CellID->628761450,ExpressionUUID->"96322430-e73f-4f4c-91d5-105db0a1c389"],
 
 Cell["There are only two reasons to use this function:", "Notes",
- CellChangeTimes->{{3.823677639162159*^9, 3.8236776556580143`*^9}, {
+ CellChangeTimes->{{3.823677639162159*^9, 3.823677655658015*^9}, {
   3.823678202744749*^9, 3.823678203209507*^9}},
  CellID->1067943069,ExpressionUUID->"843a0f6e-824a-4369-bf0a-a16fc7f6a110"],
 
 Cell["1. If REFPROP is installed in a non-standard location.", "Notes",
- CellChangeTimes->{{3.8236778444969263`*^9, 3.8236778582013025`*^9}},
+ CellChangeTimes->{{3.8236778444969273`*^9, 3.8236778582013035`*^9}},
  CellID->285126097,ExpressionUUID->"f3f3a719-1fb8-48e1-bd99-fe519a1cedb3"],
 
 Cell["\<\
 2. To debug RefpropLink with different versions of REFPROP (developers).\
 \>", "Notes",
- CellChangeTimes->{{3.8236778444969263`*^9, 3.8236779035449905`*^9}, {
-  3.8236965222994347`*^9, 3.823696525611517*^9}},
+ CellChangeTimes->{{3.8236778444969273`*^9, 3.8236779035449905`*^9}, {
+  3.823696522299435*^9, 3.823696525611517*^9}},
  CellID->248552183,ExpressionUUID->"6b5f414a-bf5d-48af-92d1-6353ed5ac8d0"],
 
 Cell[TextData[{
@@ -97,8 +102,8 @@ appropriate 64-bit, REFPROP DLL (",
   FontWeight->"Normal"],
  ") to use; storing the full path to the DLL internally."
 }], "Notes",
- CellChangeTimes->{{3.823677970685438*^9, 3.8236780858254685`*^9}, 
-   3.823696842297361*^9, {3.823711580221387*^9, 3.8237115809404645`*^9}},
+ CellChangeTimes->{{3.823677970685438*^9, 3.823678085825468*^9}, 
+   3.823696842297361*^9, {3.823711580221387*^9, 3.823711580940465*^9}},
  CellID->490976266,ExpressionUUID->"e84ddfef-e547-4168-b4e0-db1bf77d450d"],
 
 Cell[TextData[{
@@ -120,17 +125,18 @@ Cell[TextData[{
  " is an optional parameter that if omitted, or set to 0, will cause the DLL \
 location to be set temporarily; for this session only.  If set to 1, the \
 setting will be written to a RefpropLink resource file, making it the default \
-location for future RefpropLink sessions."
+location for future RefpropLink sessions.  If set to -1, the currently stored \
+DLL path is returned."
 }], "Notes",
  CellChangeTimes->{{3.823682191121419*^9, 3.823682337718405*^9}, 
-   3.8236967653503857`*^9},
+   3.823696765350386*^9, {3.9204332228403015`*^9, 3.920433246822197*^9}},
  CellID->569073670,ExpressionUUID->"0f2a494a-baf5-4a5a-9c9b-688436fddbdc"],
 
 Cell["\<\
 If the new DLL location is set correctly, the selected REFPROP version will \
 be displayed, just like it does when loading the RefpropLink context.\
 \>", "Notes",
- CellChangeTimes->{{3.8237116655801067`*^9, 3.8237117354113293`*^9}},
+ CellChangeTimes->{{3.823711665580107*^9, 3.8237117354113297`*^9}},
  CellID->320057073,ExpressionUUID->"182693a5-8f4c-4b0b-8fdd-6e424c634010"],
 
 Cell[TextData[{
@@ -143,7 +149,7 @@ Cell[TextData[{
    ButtonData->"paclet:RefpropLink/ref/SetPath"]], "InlineFormula",
   ExpressionUUID->"3cf4954a-12e9-4fef-b5a9-0ae2b8378b41"],
  " will automatically be called as well, so that REFPROP knows where to find \
-the fluid and mixture files that are installed on level below the REFPROP \
+the fluid and mixture files that are installed one level below the REFPROP \
 installation directory.  If the fluids and mixtures files are located \
 elsewhere, then ",
  Cell[BoxData[
@@ -155,7 +161,7 @@ elsewhere, then ",
 }], "Notes",
  CellChangeTimes->{{3.82370044267901*^9, 3.8237005125101056`*^9}, 
    3.8237005556317606`*^9, {3.82382360703895*^9, 3.823823714466613*^9}, {
-   3.8857053757086334`*^9, 3.8857053757086334`*^9}},
+   3.8857053757086334`*^9, 3.8857053757086334`*^9}, 3.9204332813921604`*^9},
  Background->RGBColor[1, 1, 0.85],
  CellID->141459584,ExpressionUUID->"42834247-97a6-43a7-972e-17d4f328ca99"]
 }, Open  ]],
@@ -179,15 +185,15 @@ Cell[TextData[{
 Cell[TextData[ButtonBox["Pure Fluids",
  BaseStyle->"Link",
  ButtonData->"paclet:RefpropLink/tutorial/PureFluids"]], "Tutorials",
- CellChangeTimes->{{3.8850449912453327`*^9, 3.885044995676924*^9}, 
-   3.8851352721559625`*^9},
+ CellChangeTimes->{{3.885044991245333*^9, 3.885044995676924*^9}, 
+   3.885135272155963*^9},
  CellID->13066403,ExpressionUUID->"1826503d-eb32-44b4-b68c-f4582b7b60ef"],
 
 Cell[TextData[ButtonBox["Mixtures",
  BaseStyle->"Link",
  ButtonData->"paclet:RefpropLink/tutorial/Mixtures"]], "Tutorials",
- CellChangeTimes->{{3.8850449994368477`*^9, 3.885045000645773*^9}, 
-   3.8851352763261013`*^9},
+ CellChangeTimes->{{3.885044999436847*^9, 3.885045000645773*^9}, 
+   3.885135276326102*^9},
  CellID->532672714,ExpressionUUID->"52607231-cd89-4059-969d-40b72182014d"],
 
 Cell[TextData[ButtonBox["RefpropLink Implementation",
@@ -202,7 +208,7 @@ Cell[TextData[ButtonBox["RefpropLink Units",
  BaseStyle->"Link",
  ButtonData->"paclet:RefpropLink/tutorial/RefpropLinkUnits"]], "Tutorials",
  CellChangeTimes->{{3.885045012805377*^9, 3.885045016382086*^9}, 
-   3.8851352863659077`*^9},
+   3.885135286365908*^9},
  CellID->78972548,ExpressionUUID->"ca54bdc4-9a4b-44f8-87ba-74aac7d5407c"]
 }, Open  ]],
 
@@ -294,10 +300,10 @@ Cell[TextData[{
     "8fafdadc-5b33-44b3-a74e-c7639393287c"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "71e46437-b5e6-46db-a298-a0b1a513c9e7", 
-     "d69969cb-cb7f-46b7-958b-fb0b058c35c5"], $CellContext`cellobj$$ = 
+     "32d0760c-0803-4344-856c-49d64e387e7c"], $CellContext`cellobj$$ = 
     CellObject[
     "dbcbf888-1e77-40d8-bfec-d95d58c8c769", 
-     "2cc7f767-1205-4bb0-89e0-b75a19460e01"]}, 
+     "ff60b524-0a32-6f40-93c4-ab3064ccb2d9"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -392,7 +398,7 @@ the FileOpen dialog.\
 
 Cell[BoxData[
  RowBox[{"SetDLL", "[", "]"}]], "Input",
- CellChangeTimes->{{3.8237117579440327`*^9, 3.8237117617997203`*^9}},
+ CellChangeTimes->{{3.823711757944034*^9, 3.823711761799721*^9}},
  CellLabel->"In[1]:=",
  CellID->301866692,ExpressionUUID->"04ce58ca-b00c-4c18-a9d4-a8766e8eca45"],
 
@@ -915,15 +921,15 @@ URCrgQ==
   ImageSize->Automatic,
   ImageSizeRaw->{576.75, 291.},
   PlotRange->{{0, 576.75}, {0, 291.}}]], "Input",
- CellChangeTimes->{{3.8238276952931066`*^9, 3.8238276975590296`*^9}},
+ CellChangeTimes->{{3.823827695293106*^9, 3.823827697559029*^9}},
  CellID->151498556,ExpressionUUID->"c5cb740a-e50b-4260-99ef-669214304e14"],
 
 Cell["\<\
 \[LineSeparator]After selecting the a valid 64-bit DLL, the version of the \
 REFPROP DLL file is returned.\[LineSeparator]\
 \>", "ExampleText",
- CellChangeTimes->{{3.8237124507719784`*^9, 3.823712499218398*^9}, {
-  3.8237198700842123`*^9, 3.82371987233918*^9}, {3.829547098376793*^9, 
+ CellChangeTimes->{{3.823712450771979*^9, 3.823712499218398*^9}, {
+  3.823719870084213*^9, 3.82371987233918*^9}, {3.829547098376793*^9, 
   3.829547099864809*^9}},
  CellID->19797663,ExpressionUUID->"c7ab0646-cbae-4f52-9a2d-67415674d96e"],
 
@@ -952,14 +958,14 @@ subsequent Mathematica sessions (every time RefpropLink is reloaded).  No \
 messages are provided other than the version banner already demonstrated \
 above.\
 \>", "ExampleText",
- CellChangeTimes->{{3.829553018994162*^9, 3.8295531607940493`*^9}},
+ CellChangeTimes->{{3.829553018994162*^9, 3.829553160794049*^9}},
  CellID->156934988,ExpressionUUID->"9c94d0b7-b2b6-46c3-aabc-573f8d300557"],
 
 Cell[CellGroupData[{
 
 Cell[BoxData[
  RowBox[{"SetDLL", "[", "1", "]"}]], "Input",
- CellChangeTimes->{{3.8295531663821096`*^9, 3.829553171301956*^9}},
+ CellChangeTimes->{{3.829553166382109*^9, 3.829553171301956*^9}},
  CellLabel->"In[78]:=",
  CellID->30572568,ExpressionUUID->"a6aa347f-6d75-498c-bfdc-fa621cc1f08b"],
 
@@ -1139,27 +1145,27 @@ Cell["NIST REFPROP", "Keywords",
 
 Cell["RefProp", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364874468565`*^9, 3.8851365014567456`*^9}},
+  3.885136487446857*^9, 3.8851365014567456`*^9}},
  CellID->681729142,ExpressionUUID->"3ec3b8b7-f7a9-495a-9a72-152de17bd99f"],
 
 Cell["Thermodynamics", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364874468565`*^9, 3.8851365046612825`*^9}},
+  3.885136487446857*^9, 3.8851365046612825`*^9}},
  CellID->56991772,ExpressionUUID->"9ae0b5bc-548c-4201-8429-d060868cad81"],
 
 Cell["Properties", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364891166363`*^9, 3.8851364912063107`*^9}},
+  3.8851364891166368`*^9, 3.885136491206311*^9}},
  CellID->475629817,ExpressionUUID->"32933b65-2d76-40ff-8758-35154c5fff2f"],
 
 Cell["Fluids", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364891166363`*^9, 3.8851365083008103`*^9}},
+  3.8851364891166368`*^9, 3.885136508300811*^9}},
  CellID->286615801,ExpressionUUID->"29c8d4d4-1662-4f51-9c1f-fff94f3ce0e8"],
 
 Cell["Mixtures", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364891166363`*^9, 3.885136511285285*^9}},
+  3.8851364891166368`*^9, 3.885136511285285*^9}},
  CellID->804040460,ExpressionUUID->"38515f2a-680f-4d88-8495-a3d7302d3022"]
 }, Open  ]],
 
@@ -1190,7 +1196,7 @@ WindowSize->{700.5, 765.75},
 WindowMargins->{{4.5, Automatic}, {Automatic, 0}},
 TaggingRules-><|"Paclet" -> "RefpropLink"|>,
 CellContext->"Global`",
-FrontEndVersion->"13.2 for Microsoft Windows (64-bit) (November 18, 2022)",
+FrontEndVersion->"14.0 for Microsoft Windows (64-bit) (December 12, 2023)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"71e46437-b5e6-46db-a298-a0b1a513c9e7"
@@ -1201,14 +1207,14 @@ ExpressionUUID->"71e46437-b5e6-46db-a298-a0b1a513c9e7"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[48307, 979, 486, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"d37ac475-ce49-4cc4-8bed-1222a3e08d29",
+  Cell[48688, 985, 486, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"d37ac475-ce49-4cc4-8bed-1222a3e08d29",
    CellTags->"ExtendedExamples",
    CellID->61457581]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 56249, 1202}
+ {"ExtendedExamples", 56622, 1208}
  }
 *)
 (*NotebookFileOutline
@@ -1216,167 +1222,167 @@ Notebook[{
 Cell[CellGroupData[{
 Cell[580, 22, 103, 1, 74, "ObjectName",ExpressionUUID->"b22ce942-fc06-4a79-a9c2-d2f433c57ba9",
  CellID->423151275],
-Cell[686, 25, 1559, 33, 194, "Usage",ExpressionUUID->"a01abdac-8616-43c7-8d5f-40b9fc5bce22",
+Cell[686, 25, 1845, 38, 194, "Usage",ExpressionUUID->"a01abdac-8616-43c7-8d5f-40b9fc5bce22",
  CellID->141853299],
-Cell[2248, 60, 390, 9, 45, "Notes",ExpressionUUID->"96322430-e73f-4f4c-91d5-105db0a1c389",
+Cell[2534, 65, 390, 9, 45, "Notes",ExpressionUUID->"96322430-e73f-4f4c-91d5-105db0a1c389",
  CellID->628761450],
-Cell[2641, 71, 258, 3, 27, "Notes",ExpressionUUID->"843a0f6e-824a-4369-bf0a-a16fc7f6a110",
+Cell[2927, 76, 256, 3, 27, "Notes",ExpressionUUID->"843a0f6e-824a-4369-bf0a-a16fc7f6a110",
  CellID->1067943069],
-Cell[2902, 76, 216, 2, 27, "Notes",ExpressionUUID->"f3f3a719-1fb8-48e1-bd99-fe519a1cedb3",
+Cell[3186, 81, 216, 2, 27, "Notes",ExpressionUUID->"f3f3a719-1fb8-48e1-bd99-fe519a1cedb3",
  CellID->285126097],
-Cell[3121, 80, 293, 5, 27, "Notes",ExpressionUUID->"6b5f414a-bf5d-48af-92d1-6353ed5ac8d0",
+Cell[3405, 85, 291, 5, 27, "Notes",ExpressionUUID->"6b5f414a-bf5d-48af-92d1-6353ed5ac8d0",
  CellID->248552183],
-Cell[3417, 87, 629, 14, 45, "Notes",ExpressionUUID->"e84ddfef-e547-4168-b4e0-db1bf77d450d",
+Cell[3699, 92, 625, 14, 45, "Notes",ExpressionUUID->"e84ddfef-e547-4168-b4e0-db1bf77d450d",
  CellID->490976266],
-Cell[4049, 103, 448, 10, 45, "Notes",ExpressionUUID->"cdbdf11e-530e-4414-a768-d9a1a564b3d9",
+Cell[4327, 108, 448, 10, 45, "Notes",ExpressionUUID->"cdbdf11e-530e-4414-a768-d9a1a564b3d9",
  CellID->271481758],
-Cell[4500, 115, 595, 11, 63, "Notes",ExpressionUUID->"0f2a494a-baf5-4a5a-9c9b-688436fddbdc",
+Cell[4778, 120, 701, 12, 63, "Notes",ExpressionUUID->"0f2a494a-baf5-4a5a-9c9b-688436fddbdc",
  CellID->569073670],
-Cell[5098, 128, 317, 5, 45, "Notes",ExpressionUUID->"182693a5-8f4c-4b0b-8fdd-6e424c634010",
+Cell[5482, 134, 315, 5, 45, "Notes",ExpressionUUID->"182693a5-8f4c-4b0b-8fdd-6e424c634010",
  CellID->320057073],
-Cell[5418, 135, 1103, 24, 83, "Notes",ExpressionUUID->"42834247-97a6-43a7-972e-17d4f328ca99",
+Cell[5800, 141, 1128, 24, 83, "Notes",ExpressionUUID->"42834247-97a6-43a7-972e-17d4f328ca99",
  CellID->141459584]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[6558, 164, 435, 12, 46, "TechNotesSection",ExpressionUUID->"968b7733-e658-416e-b3e1-c122d3d23c65",
+Cell[6965, 170, 435, 12, 40, "TechNotesSection",ExpressionUUID->"968b7733-e658-416e-b3e1-c122d3d23c65",
  CellID->191981068],
-Cell[6996, 178, 298, 5, 19, "Tutorials",ExpressionUUID->"1826503d-eb32-44b4-b68c-f4582b7b60ef",
+Cell[7403, 184, 294, 5, 19, "Tutorials",ExpressionUUID->"1826503d-eb32-44b4-b68c-f4582b7b60ef",
  CellID->13066403],
-Cell[7297, 185, 294, 5, 19, "Tutorials",ExpressionUUID->"52607231-cd89-4059-969d-40b72182014d",
+Cell[7700, 191, 290, 5, 19, "Tutorials",ExpressionUUID->"52607231-cd89-4059-969d-40b72182014d",
  CellID->532672714],
-Cell[7594, 192, 330, 6, 19, "Tutorials",ExpressionUUID->"17fde571-a336-40c3-84ae-0a09b1b1ff39",
+Cell[7993, 198, 330, 6, 19, "Tutorials",ExpressionUUID->"17fde571-a336-40c3-84ae-0a09b1b1ff39",
  CellID->353786990],
-Cell[7927, 200, 308, 5, 19, "Tutorials",ExpressionUUID->"ca54bdc4-9a4b-44f8-87ba-74aac7d5407c",
+Cell[8326, 206, 306, 5, 19, "Tutorials",ExpressionUUID->"ca54bdc4-9a4b-44f8-87ba-74aac7d5407c",
  CellID->78972548]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[8272, 210, 472, 13, 33, "RelatedLinksSection",ExpressionUUID->"5b03be42-bcc1-4621-87b1-61bce91111fb",
+Cell[8669, 216, 472, 13, 39, "RelatedLinksSection",ExpressionUUID->"5b03be42-bcc1-4621-87b1-61bce91111fb",
  CellID->244109481],
-Cell[8747, 225, 402, 10, 19, "RelatedLinks",ExpressionUUID->"433a9d9a-fef2-4d61-901c-2dbc118ccbed",
+Cell[9144, 231, 402, 10, 19, "RelatedLinks",ExpressionUUID->"433a9d9a-fef2-4d61-901c-2dbc118ccbed",
  CellID->316797178],
-Cell[9152, 237, 366, 9, 19, "RelatedLinks",ExpressionUUID->"54a6661b-082d-404e-a25f-b43a79c8fdac",
+Cell[9549, 243, 366, 9, 19, "RelatedLinks",ExpressionUUID->"54a6661b-082d-404e-a25f-b43a79c8fdac",
  CellID->73139884]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[9555, 251, 458, 13, 33, "SeeAlsoSection",ExpressionUUID->"50665715-f186-4517-87a3-b44fb62d7748",
+Cell[9952, 257, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"50665715-f186-4517-87a3-b44fb62d7748",
  CellID->251062271],
-Cell[10016, 266, 2496, 60, 24, "SeeAlso",ExpressionUUID->"32a55437-a6a8-4c13-ad8d-ef8344bbd920",
+Cell[10413, 272, 2496, 60, 24, "SeeAlso",ExpressionUUID->"32a55437-a6a8-4c13-ad8d-ef8344bbd920",
  CellID->93382130]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[12549, 331, 183, 2, 33, "MoreAboutSection",ExpressionUUID->"31c1baf1-5329-44b0-9f64-390b5af4ba7a",
+Cell[12946, 337, 183, 2, 39, "MoreAboutSection",ExpressionUUID->"31c1baf1-5329-44b0-9f64-390b5af4ba7a",
  CellID->562829736],
-Cell[12735, 335, 365, 8, 22, "MoreAbout",ExpressionUUID->"d388c6d9-e502-4752-80d4-6e2768c9e975",
+Cell[13132, 341, 365, 8, 22, "MoreAbout",ExpressionUUID->"d388c6d9-e502-4752-80d4-6e2768c9e975",
  CellID->19108793]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[13137, 348, 529, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"e5cf1158-a807-41ed-987b-7034e72d1fd1",
+Cell[13534, 354, 529, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"e5cf1158-a807-41ed-987b-7034e72d1fd1",
  CellID->38503084],
-Cell[13669, 364, 167, 2, 45, "ExampleInitialization",ExpressionUUID->"f8bbb003-f467-47b6-a4a0-227aa80f0c75",
+Cell[14066, 370, 167, 2, 45, "ExampleInitialization",ExpressionUUID->"f8bbb003-f467-47b6-a4a0-227aa80f0c75",
  CellID->30814300]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[13873, 371, 442, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"153ffeaf-3170-4606-8b0d-c0ecbf175d63",
+Cell[14270, 377, 442, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"153ffeaf-3170-4606-8b0d-c0ecbf175d63",
  CellID->296136684],
-Cell[14318, 385, 271, 5, 24, "ExampleText",ExpressionUUID->"336f850f-005d-4259-9430-97f691e81861",
+Cell[14715, 391, 271, 5, 24, "ExampleText",ExpressionUUID->"336f850f-005d-4259-9430-97f691e81861",
  CellID->456168726],
-Cell[14592, 392, 222, 4, 25, "Input",ExpressionUUID->"04ce58ca-b00c-4c18-a9d4-a8766e8eca45",
+Cell[14989, 398, 218, 4, 25, "Input",ExpressionUUID->"04ce58ca-b00c-4c18-a9d4-a8766e8eca45",
  CellID->301866692],
-Cell[14817, 398, 188, 2, 24, "ExampleText",ExpressionUUID->"323406b9-c2e5-4ef3-8596-e502fecf16aa",
+Cell[15210, 404, 188, 2, 24, "ExampleText",ExpressionUUID->"323406b9-c2e5-4ef3-8596-e502fecf16aa",
  CellID->116396848],
-Cell[15008, 402, 31178, 516, 250, "Input",ExpressionUUID->"c5cb740a-e50b-4260-99ef-669214304e14",
+Cell[15401, 408, 31174, 516, 250, "Input",ExpressionUUID->"c5cb740a-e50b-4260-99ef-669214304e14",
  CellID->151498556],
-Cell[46189, 920, 394, 7, 58, "ExampleText",ExpressionUUID->"c7ab0646-cbae-4f52-9a2d-67415674d96e",
+Cell[46578, 926, 390, 7, 58, "ExampleText",ExpressionUUID->"c7ab0646-cbae-4f52-9a2d-67415674d96e",
  CellID->19797663],
-Cell[46586, 929, 328, 7, 34, "Print",ExpressionUUID->"29ed213e-9f1a-484e-88c5-8e38ce9c2afc",
+Cell[46971, 935, 328, 7, 34, "Print",ExpressionUUID->"29ed213e-9f1a-484e-88c5-8e38ce9c2afc",
  CellID->544651593],
 Cell[CellGroupData[{
-Cell[46939, 940, 241, 5, 20, "ExampleDelimiter",ExpressionUUID->"c4c36070-a30f-48db-9251-daa02b7cbbf6",
+Cell[47324, 946, 241, 5, 20, "ExampleDelimiter",ExpressionUUID->"c4c36070-a30f-48db-9251-daa02b7cbbf6",
  CellID->48714072],
-Cell[47183, 947, 481, 8, 58, "ExampleText",ExpressionUUID->"9c94d0b7-b2b6-46c3-aabc-573f8d300557",
+Cell[47568, 953, 479, 8, 58, "ExampleText",ExpressionUUID->"9c94d0b7-b2b6-46c3-aabc-573f8d300557",
  CellID->156934988],
 Cell[CellGroupData[{
-Cell[47689, 959, 225, 4, 25, "Input",ExpressionUUID->"a6aa347f-6d75-498c-bfdc-fa621cc1f08b",
+Cell[48072, 965, 223, 4, 25, "Input",ExpressionUUID->"a6aa347f-6d75-498c-bfdc-fa621cc1f08b",
  CellID->30572568],
-Cell[47917, 965, 329, 7, 34, "Print",ExpressionUUID->"f61c3433-e7ff-4e83-9594-0cb1a9ed5de8",
+Cell[48298, 971, 329, 7, 34, "Print",ExpressionUUID->"f61c3433-e7ff-4e83-9594-0cb1a9ed5de8",
  CellID->790101342]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[48307, 979, 486, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"d37ac475-ce49-4cc4-8bed-1222a3e08d29",
+Cell[48688, 985, 486, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"d37ac475-ce49-4cc4-8bed-1222a3e08d29",
  CellTags->"ExtendedExamples",
  CellID->61457581],
-Cell[48796, 994, 241, 5, 35, "ExampleSection",ExpressionUUID->"a17eb3b3-c70e-49ea-b32b-c0e53205b0d3",
+Cell[49177, 1000, 241, 5, 35, "ExampleSection",ExpressionUUID->"a17eb3b3-c70e-49ea-b32b-c0e53205b0d3",
  CellID->310055386],
-Cell[49040, 1001, 264, 5, 23, "ExampleSection",ExpressionUUID->"83aa8d35-827f-49d1-baa0-4102a863332f",
+Cell[49421, 1007, 264, 5, 23, "ExampleSection",ExpressionUUID->"83aa8d35-827f-49d1-baa0-4102a863332f",
  CellID->496332059],
 Cell[CellGroupData[{
-Cell[49329, 1010, 243, 5, 23, "ExampleSection",ExpressionUUID->"dd8629ae-9af0-4dbc-87a1-1f2fcb03493d",
+Cell[49710, 1016, 243, 5, 23, "ExampleSection",ExpressionUUID->"dd8629ae-9af0-4dbc-87a1-1f2fcb03493d",
  CellID->463563952],
-Cell[49575, 1017, 245, 5, 26, "ExampleSubsection",ExpressionUUID->"13f57de2-c376-481c-af5f-a32063570d35",
+Cell[49956, 1023, 245, 5, 26, "ExampleSubsection",ExpressionUUID->"13f57de2-c376-481c-af5f-a32063570d35",
  CellID->30948521],
-Cell[49823, 1024, 246, 5, 22, "ExampleSubsection",ExpressionUUID->"c363fcd0-14d3-4bd6-bd45-da82589cfa48",
+Cell[50204, 1030, 246, 5, 22, "ExampleSubsection",ExpressionUUID->"c363fcd0-14d3-4bd6-bd45-da82589cfa48",
  CellID->442372092]
 }, Open  ]],
-Cell[50084, 1032, 247, 5, 35, "ExampleSection",ExpressionUUID->"55d7cc79-539c-4e54-8a2e-436b25ebcb27",
+Cell[50465, 1038, 247, 5, 35, "ExampleSection",ExpressionUUID->"55d7cc79-539c-4e54-8a2e-436b25ebcb27",
  CellID->33986551],
-Cell[50334, 1039, 257, 5, 23, "ExampleSection",ExpressionUUID->"b280496c-491a-4dc9-b35d-710b98318b06",
+Cell[50715, 1045, 257, 5, 23, "ExampleSection",ExpressionUUID->"b280496c-491a-4dc9-b35d-710b98318b06",
  CellID->91521914],
-Cell[50594, 1046, 251, 5, 23, "ExampleSection",ExpressionUUID->"aa306c4c-5541-4a98-ab64-6fc96e73df9c",
+Cell[50975, 1052, 251, 5, 23, "ExampleSection",ExpressionUUID->"aa306c4c-5541-4a98-ab64-6fc96e73df9c",
  CellID->520394892],
-Cell[50848, 1053, 255, 5, 23, "ExampleSection",ExpressionUUID->"87d6cd93-5016-48e2-8789-e98f40d95aa9",
+Cell[51229, 1059, 255, 5, 23, "ExampleSection",ExpressionUUID->"87d6cd93-5016-48e2-8789-e98f40d95aa9",
  CellID->44897943],
-Cell[51106, 1060, 248, 5, 23, "ExampleSection",ExpressionUUID->"2dbf1364-5c14-4442-85b2-97c7504c462c",
+Cell[51487, 1066, 248, 5, 23, "ExampleSection",ExpressionUUID->"2dbf1364-5c14-4442-85b2-97c7504c462c",
  CellID->62805351]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[51391, 1070, 110, 1, 72, "MetadataSection",ExpressionUUID->"9dcd6a84-7100-4762-b004-087948951d4f",
+Cell[51772, 1076, 110, 1, 72, "MetadataSection",ExpressionUUID->"9dcd6a84-7100-4762-b004-087948951d4f",
  CellID->244632091],
-Cell[51504, 1073, 598, 13, 26, "History",ExpressionUUID->"fd9bc0fe-713f-43e0-9362-7fbbd25a8833",
+Cell[51885, 1079, 598, 13, 26, "History",ExpressionUUID->"fd9bc0fe-713f-43e0-9362-7fbbd25a8833",
  CellID->394266960],
 Cell[CellGroupData[{
-Cell[52127, 1090, 484, 13, 21, "CategorizationSection",ExpressionUUID->"26de8c90-4668-46e6-8b80-8b5f8fef44a2",
+Cell[52508, 1096, 484, 13, 21, "CategorizationSection",ExpressionUUID->"26de8c90-4668-46e6-8b80-8b5f8fef44a2",
  CellID->187818210],
-Cell[52614, 1105, 134, 2, 35, "Categorization",ExpressionUUID->"14d5f00f-9aa4-4079-bcfc-e0badb5a2bd5",
+Cell[52995, 1111, 134, 2, 35, "Categorization",ExpressionUUID->"14d5f00f-9aa4-4079-bcfc-e0badb5a2bd5",
  CellID->588613950],
-Cell[52751, 1109, 138, 2, 35, "Categorization",ExpressionUUID->"ffcf66f2-faac-4a3d-bd21-233af9a4c0d4",
+Cell[53132, 1115, 138, 2, 35, "Categorization",ExpressionUUID->"ffcf66f2-faac-4a3d-bd21-233af9a4c0d4",
  CellID->13649986],
-Cell[52892, 1113, 136, 2, 35, "Categorization",ExpressionUUID->"5a65237c-4801-4efd-bfd3-ea1d046151b1",
+Cell[53273, 1119, 136, 2, 35, "Categorization",ExpressionUUID->"5a65237c-4801-4efd-bfd3-ea1d046151b1",
  CellID->795056406],
-Cell[53031, 1117, 140, 2, 35, "Categorization",ExpressionUUID->"607b5a7e-f439-4150-abbf-7cd99bc3cda2",
+Cell[53412, 1123, 140, 2, 35, "Categorization",ExpressionUUID->"607b5a7e-f439-4150-abbf-7cd99bc3cda2",
  CellID->6897005]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[53208, 1124, 110, 1, 21, "KeywordsSection",ExpressionUUID->"4e48620f-b96e-4382-ae65-da081b524118",
+Cell[53589, 1130, 110, 1, 21, "KeywordsSection",ExpressionUUID->"4e48620f-b96e-4382-ae65-da081b524118",
  CellID->103065811],
-Cell[53321, 1127, 176, 2, 21, "Keywords",ExpressionUUID->"e0dd880f-a771-4f0d-a89f-0119bfb64a0e",
+Cell[53702, 1133, 176, 2, 21, "Keywords",ExpressionUUID->"e0dd880f-a771-4f0d-a89f-0119bfb64a0e",
  CellID->268521556],
-Cell[53500, 1131, 172, 2, 21, "Keywords",ExpressionUUID->"aeffc51a-f8fa-428f-9b29-a7675e99b9d3",
+Cell[53881, 1137, 172, 2, 21, "Keywords",ExpressionUUID->"aeffc51a-f8fa-428f-9b29-a7675e99b9d3",
  CellID->413381409],
-Cell[53675, 1135, 174, 2, 21, "Keywords",ExpressionUUID->"de6c30e3-89b7-4cd5-875f-2bdaebf704d5",
+Cell[54056, 1141, 174, 2, 21, "Keywords",ExpressionUUID->"de6c30e3-89b7-4cd5-875f-2bdaebf704d5",
  CellID->79312569],
-Cell[53852, 1139, 223, 3, 21, "Keywords",ExpressionUUID->"3ec3b8b7-f7a9-495a-9a72-152de17bd99f",
+Cell[54233, 1145, 221, 3, 21, "Keywords",ExpressionUUID->"3ec3b8b7-f7a9-495a-9a72-152de17bd99f",
  CellID->681729142],
-Cell[54078, 1144, 229, 3, 21, "Keywords",ExpressionUUID->"9ae0b5bc-548c-4201-8429-d060868cad81",
+Cell[54457, 1150, 227, 3, 21, "Keywords",ExpressionUUID->"9ae0b5bc-548c-4201-8429-d060868cad81",
  CellID->56991772],
-Cell[54310, 1149, 226, 3, 21, "Keywords",ExpressionUUID->"32933b65-2d76-40ff-8758-35154c5fff2f",
+Cell[54687, 1155, 224, 3, 21, "Keywords",ExpressionUUID->"32933b65-2d76-40ff-8758-35154c5fff2f",
  CellID->475629817],
-Cell[54539, 1154, 222, 3, 21, "Keywords",ExpressionUUID->"29c8d4d4-1662-4f51-9c1f-fff94f3ce0e8",
+Cell[54914, 1160, 220, 3, 21, "Keywords",ExpressionUUID->"29c8d4d4-1662-4f51-9c1f-fff94f3ce0e8",
  CellID->286615801],
-Cell[54764, 1159, 222, 3, 21, "Keywords",ExpressionUUID->"38515f2a-680f-4d88-8495-a3d7302d3022",
+Cell[55137, 1165, 222, 3, 21, "Keywords",ExpressionUUID->"38515f2a-680f-4d88-8495-a3d7302d3022",
  CellID->804040460]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[55023, 1167, 118, 1, 31, "TemplatesSection",ExpressionUUID->"2b6a6ac2-d3d8-4a6f-8923-067b4415da22",
+Cell[55396, 1173, 118, 1, 31, "TemplatesSection",ExpressionUUID->"2b6a6ac2-d3d8-4a6f-8923-067b4415da22",
  CellID->54815411],
-Cell[55144, 1170, 148, 2, 70, "Template",ExpressionUUID->"d2b04389-9ea8-4167-b22f-50aacb941dad",
+Cell[55517, 1176, 148, 2, 70, "Template",ExpressionUUID->"d2b04389-9ea8-4167-b22f-50aacb941dad",
  CellID->253941555],
-Cell[55295, 1174, 137, 2, 70, "Template",ExpressionUUID->"7b2e1fd8-08cc-4fba-9967-3c4f7418fbbc",
+Cell[55668, 1180, 137, 2, 70, "Template",ExpressionUUID->"7b2e1fd8-08cc-4fba-9967-3c4f7418fbbc",
  CellID->357175093],
-Cell[55435, 1178, 135, 2, 70, "Template",ExpressionUUID->"ecfaf329-2c92-4675-903e-f1e304ed87a2",
+Cell[55808, 1184, 135, 2, 70, "Template",ExpressionUUID->"ecfaf329-2c92-4675-903e-f1e304ed87a2",
  CellID->413012485],
-Cell[55573, 1182, 135, 2, 70, "Template",ExpressionUUID->"3cea3ac4-a9f9-40fa-b1f7-62d8dcffd4c4",
+Cell[55946, 1188, 135, 2, 70, "Template",ExpressionUUID->"3cea3ac4-a9f9-40fa-b1f7-62d8dcffd4c4",
  CellID->8709509]
 }, Closed]]
 }, Open  ]]

--- a/wrappers/Mathematica/RefpropLink/Documentation/English/ReferencePages/Symbols/SetPath.nb
+++ b/wrappers/Mathematica/RefpropLink/Documentation/English/ReferencePages/Symbols/SetPath.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     59582,       1352]
-NotebookOptionsPosition[     49158,       1138]
-NotebookOutlinePosition[     49945,       1164]
-CellTagsIndexPosition[     49865,       1159]
+NotebookDataLength[     60048,       1363]
+NotebookOptionsPosition[     49621,       1149]
+NotebookOutlinePosition[     50408,       1175]
+CellTagsIndexPosition[     50328,       1170]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -56,10 +56,15 @@ parameters. If ",
  Cell[BoxData[
   StyleBox["permSet", "TI"]], "InlineFormula",ExpressionUUID->
   "4032dec0-cdcb-4b5e-bf02-0209c287dc4e"],
- " = 1+ saves setting for future sessions."
+ " = 1+ saves setting for future sessions.  Passing  ",
+ Cell[BoxData[
+  StyleBox["permSet", "TI"]], "InlineFormula",ExpressionUUID->
+  "cada4d18-6057-454c-80aa-46571127c139"],
+ " = -1 will simply return the currently set fluids path."
 }], "Usage",
- CellChangeTimes->{{3.8850409911427984`*^9, 3.885040991571394*^9}, {
-   3.8851432419982295`*^9, 3.8851432485105915`*^9}, 3.8857060180138903`*^9},
+ CellChangeTimes->{{3.885040991142798*^9, 3.885040991571394*^9}, {
+   3.885143241998229*^9, 3.885143248510592*^9}, 3.8857060180138903`*^9, 
+   3.920433363156304*^9, {3.9204337077527065`*^9, 3.9204337103590355`*^9}},
  CellID->691089084,ExpressionUUID->"2b0dc524-a342-4874-83ea-46f604f4a8c4"],
 
 Cell[TextData[{
@@ -130,7 +135,7 @@ to the parent directory.  The parent directory should include both a ",
  " sub-folder; since mixture files will be searched from this same path."
 }], "Notes",
  CellChangeTimes->{{3.82369849935229*^9, 3.8236987795354457`*^9}, {
-  3.823824029394309*^9, 3.8238240388929005`*^9}},
+  3.823824029394309*^9, 3.823824038892901*^9}},
  CellID->166109123,ExpressionUUID->"89ab1585-3a65-4a81-8cdc-13c65fa60131"],
 
 Cell[TextData[{
@@ -153,7 +158,7 @@ taking ",
  " as the location and treating it as though it was selected from the \
 FileOpen dialog."
 }], "Notes",
- CellChangeTimes->{{3.8236988000565157`*^9, 3.823699042801483*^9}, {
+ CellChangeTimes->{{3.823698800056516*^9, 3.823699042801483*^9}, {
   3.823823774813233*^9, 3.8238237764697776`*^9}},
  CellID->325589237,ExpressionUUID->"a88cea97-122d-4932-b0f6-a9edf3e381eb"],
 
@@ -167,10 +172,16 @@ Cell[TextData[{
   FontWeight->"Normal"],
  " location to be set temporarily; for this session only.  If set to 1, the \
 setting will be written to a RefpropLink resource file, making it the default \
-location for future RefpropLink sessions."
+location for future RefpropLink sessions. If set to -1, the currently stored ",
+ StyleBox["FLUIDS\\",
+  FontFamily->"Courier New",
+  FontWeight->"Normal"],
+ " location is returned."
 }], "Notes",
  CellChangeTimes->{{3.823682191121419*^9, 3.823682337718405*^9}, 
-   3.8236967653503857`*^9, {3.823699070240363*^9, 3.8236991028168893`*^9}},
+   3.823696765350386*^9, {3.823699070240363*^9, 3.8236991028168893`*^9}, {
+   3.920433395208044*^9, 3.920433414320368*^9}, {3.920433736382639*^9, 
+   3.9204337649038334`*^9}},
  CellID->569073670,ExpressionUUID->"3a0344a1-3dc1-4e7c-9bd1-bf98f480a931"],
 
 Cell["\<\
@@ -190,7 +201,7 @@ fluids directory (\"",
  "\") as well as the fluids files."
 }], "Notes",
  CellChangeTimes->{{3.8238237992698174`*^9, 3.823823898934245*^9}, {
-  3.8238239535890636`*^9, 3.823823986956814*^9}},
+  3.823823953589063*^9, 3.823823986956814*^9}},
  Background->RGBColor[1, 1, 0.85],
  CellID->428436231,ExpressionUUID->"bd6d94d9-d83f-435f-80a2-156b034376cc"]
 }, Open  ]],
@@ -214,15 +225,15 @@ Cell[TextData[{
 Cell[TextData[ButtonBox["Pure Fluids",
  BaseStyle->"Link",
  ButtonData->"paclet:RefpropLink/tutorial/PureFluids"]], "Tutorials",
- CellChangeTimes->{{3.8850449912453327`*^9, 3.885044995676924*^9}, 
-   3.8851352721559625`*^9},
+ CellChangeTimes->{{3.885044991245333*^9, 3.885044995676924*^9}, 
+   3.885135272155963*^9},
  CellID->13066403,ExpressionUUID->"d1802957-cc54-477c-93b9-61d8367d01fe"],
 
 Cell[TextData[ButtonBox["Mixtures",
  BaseStyle->"Link",
  ButtonData->"paclet:RefpropLink/tutorial/Mixtures"]], "Tutorials",
- CellChangeTimes->{{3.8850449994368477`*^9, 3.885045000645773*^9}, 
-   3.8851352763261013`*^9},
+ CellChangeTimes->{{3.885044999436847*^9, 3.885045000645773*^9}, 
+   3.885135276326102*^9},
  CellID->532672714,ExpressionUUID->"a734f5fc-f4aa-4378-8469-efcffd86b963"],
 
 Cell[TextData[ButtonBox["RefpropLink Implementation",
@@ -237,7 +248,7 @@ Cell[TextData[ButtonBox["RefpropLink Units",
  BaseStyle->"Link",
  ButtonData->"paclet:RefpropLink/tutorial/RefpropLinkUnits"]], "Tutorials",
  CellChangeTimes->{{3.885045012805377*^9, 3.885045016382086*^9}, 
-   3.8851352863659077`*^9},
+   3.885135286365908*^9},
  CellID->78972548,ExpressionUUID->"f92c7893-558b-4792-8bae-131e43cbfc98"]
 }, Open  ]],
 
@@ -329,10 +340,10 @@ Cell[TextData[{
     "eebec779-29f7-41e6-b6ad-85d1409b0464"], 
    DynamicModuleBox[{$CellContext`nbobj$$ = NotebookObject[
     "85ac4592-e3af-4bb3-94ef-05dfb5d76846", 
-     "4cdf222a-a53d-4a78-a6fa-8f1f8623ec22"], $CellContext`cellobj$$ = 
+     "a7989fb7-fd64-4e46-8a77-11d478b1f71b"], $CellContext`cellobj$$ = 
     CellObject[
     "b1b54397-bc3e-47a8-ba22-832ab9e6c6a4", 
-     "f4ffd5c1-679c-4a27-b1b6-13ad1d44e04f"]}, 
+     "61d54e28-e0f3-1246-9ac8-abed5e4905fe"]}, 
     TemplateBox[{
       GraphicsBox[{{
          Thickness[0.06], 
@@ -375,7 +386,7 @@ Cell[TextData[Cell[BoxData[
    "paclet:RefpropLink/guide/RefpropLink"]], \
 "InlineFormula",ExpressionUUID->"1948a75b-5de8-4358-9e92-a0e62e6773fd"]], \
 "MoreAbout",
- CellChangeTimes->{{3.8851431181027403`*^9, 3.8851431238982267`*^9}},
+ CellChangeTimes->{{3.8851431181027403`*^9, 3.8851431238982263`*^9}},
  CellID->229334455,ExpressionUUID->"c195e716-ffda-4ca8-9d17-3eab74831d8a"]
 }, Open  ]],
 
@@ -430,7 +441,7 @@ Cell[CellGroupData[{
 Cell[BoxData[
  RowBox[{
   RowBox[{"SetPath", "[", "]"}], ";"}]], "Input",
- CellChangeTimes->{{3.8237117579440327`*^9, 3.8237117617997203`*^9}, {
+ CellChangeTimes->{{3.823711757944034*^9, 3.823711761799721*^9}, {
    3.82382420138129*^9, 3.8238242021582055`*^9}, 3.829543807912895*^9, 
    3.8295438651528625`*^9, 3.8295463422264414`*^9},
  CellLabel->"In[13]:=",
@@ -444,7 +455,7 @@ Cell[BoxData[
 \\\\\\REFPROP\\\\\\\"\\\"}]\\)].\"", 2, 13, 3, 33610983680637210755, "Local", 
    "RefpropLink`SetPath"},
   "MessageTemplate2"]], "Message", "MSG",
- CellChangeTimes->{{3.829546333205533*^9, 3.8295463477636094`*^9}},
+ CellChangeTimes->{{3.829546333205533*^9, 3.829546347763609*^9}},
  CellLabel->"During evaluation of In[13]:=",
  CellID->48509437,ExpressionUUID->"5018dbf7-7c3f-42d8-81b2-ac9e386df011"]
 }, Open  ]],
@@ -800,7 +811,7 @@ Cell["\<\
 setting the fluids directory path.\[LineSeparator]\
 \>", "ExampleText",
  CellChangeTimes->{{3.823824595358304*^9, 3.823824637844694*^9}, {
-  3.8295438865297394`*^9, 3.8295439138806095`*^9}},
+  3.829543886529739*^9, 3.8295439138806086`*^9}},
  CellID->54522394,ExpressionUUID->"26f84843-20eb-4924-a05e-d512e6e4f878"],
 
 Cell[CellGroupData[{
@@ -837,7 +848,7 @@ Cell[BoxData[
 \\\\\\REFPROP\\\\\\\"\\\"}]\\)].\"", 2, 15, 6, 33610983680637210755, "Local", 
    "RefpropLink`SetPath"},
   "MessageTemplate2"]], "Message", "MSG",
- CellChangeTimes->{{3.829546409778807*^9, 3.8295464286573343`*^9}},
+ CellChangeTimes->{{3.829546409778807*^9, 3.829546428657335*^9}},
  CellLabel->"During evaluation of In[15]:=",
  CellID->160052180,ExpressionUUID->"b1ff74ce-85a9-46c3-adc5-b6ff4b78947f"],
 
@@ -875,7 +886,7 @@ Cell[BoxData[
      RowBox[{
      "\"\<C:\>\"", ",", "\"\<Program Files (x86)\>\"", ",", 
       "\"\<REFPROP\>\""}], "}"}], "]"}], "]"}], ";"}]], "Input",
- CellChangeTimes->{{3.8295466288960056`*^9, 3.829546633128666*^9}, {
+ CellChangeTimes->{{3.829546628896005*^9, 3.829546633128666*^9}, {
   3.829546683808197*^9, 3.8295467645523205`*^9}},
  CellLabel->"In[16]:=",
  CellID->491421931,ExpressionUUID->"144d2077-4f2e-4567-aac1-4e770e1c94e0"],
@@ -888,7 +899,7 @@ Cell[BoxData[
 \\\\\\REFPROP\\\\\\\"\\\"}]\\)].\"", 2, 16, 8, 33610983680637210755, "Local", 
    "RefpropLink`SetPath"},
   "MessageTemplate2"]], "Message", "MSG",
- CellChangeTimes->{3.8295467753793783`*^9},
+ CellChangeTimes->{3.829546775379379*^9},
  CellLabel->"During evaluation of In[16]:=",
  CellID->860335059,ExpressionUUID->"c3a22e2a-d063-4f29-ba30-3b0db68dab5f"]
 }, Open  ]]
@@ -1089,27 +1100,27 @@ Cell["NIST REFPROP", "Keywords",
 
 Cell["RefProp", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364874468565`*^9, 3.8851365014567456`*^9}},
+  3.885136487446857*^9, 3.8851365014567456`*^9}},
  CellID->681729142,ExpressionUUID->"01530d82-d28b-42aa-b478-2d8ee84629a6"],
 
 Cell["Thermodynamics", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364874468565`*^9, 3.8851365046612825`*^9}},
+  3.885136487446857*^9, 3.8851365046612825`*^9}},
  CellID->56991772,ExpressionUUID->"06be9e8a-cf05-4038-98d0-7b72ac422e54"],
 
 Cell["Properties", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364891166363`*^9, 3.8851364912063107`*^9}},
+  3.8851364891166368`*^9, 3.885136491206311*^9}},
  CellID->475629817,ExpressionUUID->"a1a7decc-3a74-45b0-b6c5-e3ff0c3fb919"],
 
 Cell["Fluids", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364891166363`*^9, 3.8851365083008103`*^9}},
+  3.8851364891166368`*^9, 3.885136508300811*^9}},
  CellID->286615801,ExpressionUUID->"048092d7-b6c5-4ec8-affd-091f8091ad1f"],
 
 Cell["Mixtures", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364891166363`*^9, 3.885136511285285*^9}},
+  3.8851364891166368`*^9, 3.885136511285285*^9}},
  CellID->804040460,ExpressionUUID->"d78d3dfe-bd5d-405c-8bd5-97d99912e691"]
 }, Open  ]],
 
@@ -1140,7 +1151,7 @@ WindowSize->{700.5, 765.75},
 WindowMargins->{{4.5, Automatic}, {Automatic, 0}},
 TaggingRules-><|"Paclet" -> "RefpropLink"|>,
 CellContext->"Global`",
-FrontEndVersion->"13.2 for Microsoft Windows (64-bit) (November 18, 2022)",
+FrontEndVersion->"14.0 for Microsoft Windows (64-bit) (December 12, 2023)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "FunctionPageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"85ac4592-e3af-4bb3-94ef-05dfb5d76846"
@@ -1151,14 +1162,14 @@ ExpressionUUID->"85ac4592-e3af-4bb3-94ef-05dfb5d76846"
 (*CellTagsOutline
 CellTagsIndex->{
  "ExtendedExamples"->{
-  Cell[41731, 929, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"eb9e8d26-686a-4e30-bee0-6afb84b4f05f",
+  Cell[42202, 940, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"eb9e8d26-686a-4e30-bee0-6afb84b4f05f",
    CellTags->"ExtendedExamples",
    CellID->710146796]}
  }
 *)
 (*CellTagsIndex
 CellTagsIndex->{
- {"ExtendedExamples", 49671, 1152}
+ {"ExtendedExamples", 50134, 1163}
  }
 *)
 (*NotebookFileOutline
@@ -1166,191 +1177,191 @@ Notebook[{
 Cell[CellGroupData[{
 Cell[580, 22, 104, 1, 74, "ObjectName",ExpressionUUID->"054a1b47-d770-41b4-bf6d-e4d57269a060",
  CellID->229503143],
-Cell[687, 25, 1621, 37, 158, "Usage",ExpressionUUID->"2b0dc524-a342-4874-83ea-46f604f4a8c4",
+Cell[687, 25, 1883, 42, 158, "Usage",ExpressionUUID->"2b0dc524-a342-4874-83ea-46f604f4a8c4",
  CellID->691089084],
-Cell[2311, 64, 693, 16, 81, "Notes",ExpressionUUID->"94cf7805-f1d4-446c-abc4-b08f07bdf121",
+Cell[2573, 69, 693, 16, 81, "Notes",ExpressionUUID->"94cf7805-f1d4-446c-abc4-b08f07bdf121",
  CellID->156277655],
-Cell[3007, 82, 324, 8, 27, "Notes",ExpressionUUID->"2a900e88-2dd8-4544-813a-7873477c468d",
+Cell[3269, 87, 324, 8, 27, "Notes",ExpressionUUID->"2a900e88-2dd8-4544-813a-7873477c468d",
  CellID->526237795],
-Cell[3334, 92, 454, 8, 63, "Notes",ExpressionUUID->"706f2fc5-59ba-452a-b0cb-b7c36a7f6968",
+Cell[3596, 97, 454, 8, 63, "Notes",ExpressionUUID->"706f2fc5-59ba-452a-b0cb-b7c36a7f6968",
  CellID->45235239],
-Cell[3791, 102, 1185, 31, 99, "Notes",ExpressionUUID->"89ab1585-3a65-4a81-8cdc-13c65fa60131",
+Cell[4053, 107, 1183, 31, 99, "Notes",ExpressionUUID->"89ab1585-3a65-4a81-8cdc-13c65fa60131",
  CellID->166109123],
-Cell[4979, 135, 922, 22, 63, "Notes",ExpressionUUID->"a88cea97-122d-4932-b0f6-a9edf3e381eb",
+Cell[5239, 140, 920, 22, 63, "Notes",ExpressionUUID->"a88cea97-122d-4932-b0f6-a9edf3e381eb",
  CellID->325589237],
-Cell[5904, 159, 719, 14, 63, "Notes",ExpressionUUID->"3a0344a1-3dc1-4e7c-9bd1-bf98f480a931",
+Cell[6162, 164, 958, 20, 81, "Notes",ExpressionUUID->"3a0344a1-3dc1-4e7c-9bd1-bf98f480a931",
  CellID->569073670],
-Cell[6626, 175, 238, 5, 27, "Notes",ExpressionUUID->"db924856-2122-4f4d-8ce8-287d73b6018d",
+Cell[7123, 186, 238, 5, 27, "Notes",ExpressionUUID->"db924856-2122-4f4d-8ce8-287d73b6018d",
  CellID->117920165],
-Cell[6867, 182, 550, 12, 45, "Notes",ExpressionUUID->"bd6d94d9-d83f-435f-80a2-156b034376cc",
+Cell[7364, 193, 548, 12, 45, "Notes",ExpressionUUID->"bd6d94d9-d83f-435f-80a2-156b034376cc",
  CellID->428436231]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[7454, 199, 435, 12, 46, "TechNotesSection",ExpressionUUID->"3dcdca31-b59f-4d71-a659-b7dfba55229c",
+Cell[7949, 210, 435, 12, 40, "TechNotesSection",ExpressionUUID->"3dcdca31-b59f-4d71-a659-b7dfba55229c",
  CellID->198245635],
-Cell[7892, 213, 298, 5, 19, "Tutorials",ExpressionUUID->"d1802957-cc54-477c-93b9-61d8367d01fe",
+Cell[8387, 224, 294, 5, 19, "Tutorials",ExpressionUUID->"d1802957-cc54-477c-93b9-61d8367d01fe",
  CellID->13066403],
-Cell[8193, 220, 294, 5, 19, "Tutorials",ExpressionUUID->"a734f5fc-f4aa-4378-8469-efcffd86b963",
+Cell[8684, 231, 290, 5, 19, "Tutorials",ExpressionUUID->"a734f5fc-f4aa-4378-8469-efcffd86b963",
  CellID->532672714],
-Cell[8490, 227, 330, 6, 19, "Tutorials",ExpressionUUID->"c73449c4-9825-457b-b47d-ca4689780d08",
+Cell[8977, 238, 330, 6, 19, "Tutorials",ExpressionUUID->"c73449c4-9825-457b-b47d-ca4689780d08",
  CellID->353786990],
-Cell[8823, 235, 308, 5, 19, "Tutorials",ExpressionUUID->"f92c7893-558b-4792-8bae-131e43cbfc98",
+Cell[9310, 246, 306, 5, 19, "Tutorials",ExpressionUUID->"f92c7893-558b-4792-8bae-131e43cbfc98",
  CellID->78972548]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[9168, 245, 469, 13, 33, "RelatedLinksSection",ExpressionUUID->"863047e3-d125-436c-8319-f218b43d54e3",
+Cell[9653, 256, 469, 13, 39, "RelatedLinksSection",ExpressionUUID->"863047e3-d125-436c-8319-f218b43d54e3",
  CellID->128379],
-Cell[9640, 260, 402, 10, 19, "RelatedLinks",ExpressionUUID->"5eab318a-1f11-4b72-9eb4-347ca4b7ab35",
+Cell[10125, 271, 402, 10, 19, "RelatedLinks",ExpressionUUID->"5eab318a-1f11-4b72-9eb4-347ca4b7ab35",
  CellID->316797178],
-Cell[10045, 272, 366, 9, 19, "RelatedLinks",ExpressionUUID->"e3823a09-04e1-469d-82a2-02e23ab7f356",
+Cell[10530, 283, 366, 9, 19, "RelatedLinks",ExpressionUUID->"e3823a09-04e1-469d-82a2-02e23ab7f356",
  CellID->73139884]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10448, 286, 458, 13, 33, "SeeAlsoSection",ExpressionUUID->"95f576a9-6595-494c-82d7-50a388e918b2",
+Cell[10933, 297, 458, 13, 39, "SeeAlsoSection",ExpressionUUID->"95f576a9-6595-494c-82d7-50a388e918b2",
  CellID->113146828],
-Cell[10909, 301, 2492, 60, 24, "SeeAlso",ExpressionUUID->"e88bd2f2-9306-4971-b4bb-308ca5b31b3c",
+Cell[11394, 312, 2492, 60, 24, "SeeAlso",ExpressionUUID->"e88bd2f2-9306-4971-b4bb-308ca5b31b3c",
  CellID->306685174]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[13438, 366, 182, 2, 33, "MoreAboutSection",ExpressionUUID->"6c0505c1-a21e-4037-a9bf-7955b5f6bb24",
+Cell[13923, 377, 182, 2, 39, "MoreAboutSection",ExpressionUUID->"6c0505c1-a21e-4037-a9bf-7955b5f6bb24",
  CellID->78253496],
-Cell[13623, 370, 370, 8, 22, "MoreAbout",ExpressionUUID->"c195e716-ffda-4ca8-9d17-3eab74831d8a",
+Cell[14108, 381, 370, 8, 22, "MoreAbout",ExpressionUUID->"c195e716-ffda-4ca8-9d17-3eab74831d8a",
  CellID->229334455]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[14030, 383, 530, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"7ed4e381-c6f6-48f7-bbeb-8127afbb73e2",
+Cell[14515, 394, 530, 14, 69, "ExamplesInitializationSection",ExpressionUUID->"7ed4e381-c6f6-48f7-bbeb-8127afbb73e2",
  CellID->773210879],
-Cell[14563, 399, 167, 2, 45, "ExampleInitialization",ExpressionUUID->"5a140e92-13fd-4dbc-bd26-1b34d8112cb6",
+Cell[15048, 410, 167, 2, 45, "ExampleInitialization",ExpressionUUID->"5a140e92-13fd-4dbc-bd26-1b34d8112cb6",
  CellID->72115645]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[14767, 406, 442, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"a65a95ba-aabe-4cee-ae90-77523f238004",
+Cell[15252, 417, 442, 12, 71, "PrimaryExamplesSection",ExpressionUUID->"a65a95ba-aabe-4cee-ae90-77523f238004",
  CellID->281522787],
-Cell[15212, 420, 271, 5, 24, "ExampleText",ExpressionUUID->"9cdba220-a3c3-4b26-84d7-9d965e64d032",
+Cell[15697, 431, 271, 5, 24, "ExampleText",ExpressionUUID->"9cdba220-a3c3-4b26-84d7-9d965e64d032",
  CellID->456168726],
 Cell[CellGroupData[{
-Cell[15508, 429, 367, 7, 25, "Input",ExpressionUUID->"e57003ec-f300-4f4b-be77-b21a7633a7a2",
+Cell[15993, 440, 363, 7, 25, "Input",ExpressionUUID->"e57003ec-f300-4f4b-be77-b21a7633a7a2",
  CellID->301866692],
-Cell[15878, 438, 516, 10, 26, "Message",ExpressionUUID->"5018dbf7-7c3f-42d8-81b2-ac9e386df011",
+Cell[16359, 449, 514, 10, 26, "Message",ExpressionUUID->"5018dbf7-7c3f-42d8-81b2-ac9e386df011",
  CellID->48509437]
 }, Open  ]],
-Cell[16409, 451, 188, 2, 24, "ExampleText",ExpressionUUID->"4ac1bf53-dcfb-4a5f-a5f8-6860f6fd4f8d",
+Cell[16888, 462, 188, 2, 24, "ExampleText",ExpressionUUID->"4ac1bf53-dcfb-4a5f-a5f8-6860f6fd4f8d",
  CellID->116396848],
-Cell[16600, 455, 20472, 340, 218, "Input",ExpressionUUID->"5d2e7469-17da-4c61-bd7f-beec1c1ae53f",
+Cell[17079, 466, 20472, 340, 218, "Input",ExpressionUUID->"5d2e7469-17da-4c61-bd7f-beec1c1ae53f",
  CellID->151498556],
-Cell[37075, 797, 350, 6, 58, "ExampleText",ExpressionUUID->"26f84843-20eb-4924-a05e-d512e6e4f878",
+Cell[37554, 808, 348, 6, 58, "ExampleText",ExpressionUUID->"26f84843-20eb-4924-a05e-d512e6e4f878",
  CellID->54522394],
 Cell[CellGroupData[{
-Cell[37450, 807, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"a2adf3e6-d1e7-4384-a2f9-c39c1154d561",
+Cell[37927, 818, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"a2adf3e6-d1e7-4384-a2f9-c39c1154d561",
  CellID->652580355],
-Cell[37695, 814, 243, 4, 24, "ExampleText",ExpressionUUID->"c644bc58-2356-425d-849f-a9ca79b7b352",
+Cell[38172, 825, 243, 4, 24, "ExampleText",ExpressionUUID->"c644bc58-2356-425d-849f-a9ca79b7b352",
  CellID->17544201],
 Cell[CellGroupData[{
-Cell[37963, 822, 296, 7, 25, "Input",ExpressionUUID->"aa01e801-507c-4d8e-acab-5ea664141608",
+Cell[38440, 833, 296, 7, 25, "Input",ExpressionUUID->"aa01e801-507c-4d8e-acab-5ea664141608",
  CellID->494801597],
-Cell[38262, 831, 517, 10, 26, "Message",ExpressionUUID->"b1ff74ce-85a9-46c3-adc5-b6ff4b78947f",
+Cell[38739, 842, 515, 10, 26, "Message",ExpressionUUID->"b1ff74ce-85a9-46c3-adc5-b6ff4b78947f",
  CellID->160052180],
-Cell[38782, 843, 386, 7, 26, "Message",ExpressionUUID->"cf3758c5-00ed-45cf-93b7-17e6692b6010",
+Cell[39257, 854, 386, 7, 26, "Message",ExpressionUUID->"cf3758c5-00ed-45cf-93b7-17e6692b6010",
  CellID->380645024]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[39217, 856, 241, 5, 20, "ExampleDelimiter",ExpressionUUID->"54456fb9-4eca-4318-ba45-25890d5c56d7",
+Cell[39692, 867, 241, 5, 20, "ExampleDelimiter",ExpressionUUID->"54456fb9-4eca-4318-ba45-25890d5c56d7",
  CellID->67982763],
-Cell[39461, 863, 206, 2, 24, "ExampleText",ExpressionUUID->"382d8d75-3edb-4edc-ae49-297f11b25738",
+Cell[39936, 874, 206, 2, 24, "ExampleText",ExpressionUUID->"382d8d75-3edb-4edc-ae49-297f11b25738",
  CellID->221236628],
 Cell[CellGroupData[{
-Cell[39692, 869, 459, 11, 25, "Input",ExpressionUUID->"144d2077-4f2e-4567-aac1-4e770e1c94e0",
+Cell[40167, 880, 457, 11, 25, "Input",ExpressionUUID->"144d2077-4f2e-4567-aac1-4e770e1c94e0",
  CellID->491421931],
-Cell[40154, 882, 493, 10, 26, "Message",ExpressionUUID->"c3a22e2a-d063-4f29-ba30-3b0db68dab5f",
+Cell[40627, 893, 491, 10, 26, "Message",ExpressionUUID->"c3a22e2a-d063-4f29-ba30-3b0db68dab5f",
  CellID->860335059]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[40696, 898, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"336a5cff-b940-4628-8e0e-c97754d8b96a",
+Cell[41167, 909, 242, 5, 20, "ExampleDelimiter",ExpressionUUID->"336a5cff-b940-4628-8e0e-c97754d8b96a",
  CellID->691310678],
-Cell[40941, 905, 234, 4, 24, "ExampleText",ExpressionUUID->"3e1c20e0-3e49-476f-bbbf-602966c44d36",
+Cell[41412, 916, 234, 4, 24, "ExampleText",ExpressionUUID->"3e1c20e0-3e49-476f-bbbf-602966c44d36",
  CellID->89537566],
-Cell[41178, 911, 248, 5, 25, "Input",ExpressionUUID->"4293eb4a-468b-4b58-90d5-56f1e8b24ae0",
+Cell[41649, 922, 248, 5, 25, "Input",ExpressionUUID->"4293eb4a-468b-4b58-90d5-56f1e8b24ae0",
  CellID->551797317],
-Cell[41429, 918, 253, 5, 25, "Input",ExpressionUUID->"83e1fd7e-6bc4-49a6-a63d-87834388e2dd",
+Cell[41900, 929, 253, 5, 25, "Input",ExpressionUUID->"83e1fd7e-6bc4-49a6-a63d-87834388e2dd",
  CellID->225150821]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[41731, 929, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"eb9e8d26-686a-4e30-bee0-6afb84b4f05f",
+Cell[42202, 940, 487, 13, 57, "ExtendedExamplesSection",ExpressionUUID->"eb9e8d26-686a-4e30-bee0-6afb84b4f05f",
  CellTags->"ExtendedExamples",
  CellID->710146796],
-Cell[42221, 944, 241, 5, 35, "ExampleSection",ExpressionUUID->"44614c3f-8674-49a7-90b5-448667591d76",
+Cell[42692, 955, 241, 5, 35, "ExampleSection",ExpressionUUID->"44614c3f-8674-49a7-90b5-448667591d76",
  CellID->101474038],
-Cell[42465, 951, 264, 5, 23, "ExampleSection",ExpressionUUID->"ff48c9eb-20fa-4ec9-841f-f630d81b7253",
+Cell[42936, 962, 264, 5, 23, "ExampleSection",ExpressionUUID->"ff48c9eb-20fa-4ec9-841f-f630d81b7253",
  CellID->440877471],
 Cell[CellGroupData[{
-Cell[42754, 960, 243, 5, 23, "ExampleSection",ExpressionUUID->"d85763b9-3ca6-4bb6-acc5-546f7e56ec4d",
+Cell[43225, 971, 243, 5, 23, "ExampleSection",ExpressionUUID->"d85763b9-3ca6-4bb6-acc5-546f7e56ec4d",
  CellID->796993291],
-Cell[43000, 967, 246, 5, 26, "ExampleSubsection",ExpressionUUID->"4260c885-f62c-455a-8fe5-1b69facf2de6",
+Cell[43471, 978, 246, 5, 26, "ExampleSubsection",ExpressionUUID->"4260c885-f62c-455a-8fe5-1b69facf2de6",
  CellID->459764423],
-Cell[43249, 974, 246, 5, 22, "ExampleSubsection",ExpressionUUID->"13c67330-f6cd-4691-92dc-275eb451ec42",
+Cell[43720, 985, 246, 5, 22, "ExampleSubsection",ExpressionUUID->"13c67330-f6cd-4691-92dc-275eb451ec42",
  CellID->854324567]
 }, Open  ]],
-Cell[43510, 982, 248, 5, 35, "ExampleSection",ExpressionUUID->"bcf5ec1c-6082-4b49-bcb0-fc797f281450",
+Cell[43981, 993, 248, 5, 35, "ExampleSection",ExpressionUUID->"bcf5ec1c-6082-4b49-bcb0-fc797f281450",
  CellID->262192495],
-Cell[43761, 989, 257, 5, 23, "ExampleSection",ExpressionUUID->"6d9a81f5-817f-4139-9556-8836bfbaf918",
+Cell[44232, 1000, 257, 5, 23, "ExampleSection",ExpressionUUID->"6d9a81f5-817f-4139-9556-8836bfbaf918",
  CellID->87626847],
-Cell[44021, 996, 251, 5, 23, "ExampleSection",ExpressionUUID->"8a074347-56ec-4a72-92b4-fbb593bb8574",
+Cell[44492, 1007, 251, 5, 23, "ExampleSection",ExpressionUUID->"8a074347-56ec-4a72-92b4-fbb593bb8574",
  CellID->356303494],
-Cell[44275, 1003, 255, 5, 23, "ExampleSection",ExpressionUUID->"7463b37b-9461-4178-9368-bc45b9632e02",
+Cell[44746, 1014, 255, 5, 23, "ExampleSection",ExpressionUUID->"7463b37b-9461-4178-9368-bc45b9632e02",
  CellID->53228756],
-Cell[44533, 1010, 249, 5, 23, "ExampleSection",ExpressionUUID->"e00044f1-18f8-4e92-8d3b-97d0b871d083",
+Cell[45004, 1021, 249, 5, 23, "ExampleSection",ExpressionUUID->"e00044f1-18f8-4e92-8d3b-97d0b871d083",
  CellID->122400598]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[44819, 1020, 110, 1, 72, "MetadataSection",ExpressionUUID->"e523a0a3-1222-4e62-8b25-53a6ee7f6ebf",
+Cell[45290, 1031, 110, 1, 72, "MetadataSection",ExpressionUUID->"e523a0a3-1222-4e62-8b25-53a6ee7f6ebf",
  CellID->110934655],
-Cell[44932, 1023, 593, 13, 26, "History",ExpressionUUID->"638f7076-b43b-4ac8-9488-c5d12a0b2d0c",
+Cell[45403, 1034, 593, 13, 26, "History",ExpressionUUID->"638f7076-b43b-4ac8-9488-c5d12a0b2d0c",
  CellID->35728672],
 Cell[CellGroupData[{
-Cell[45550, 1040, 484, 13, 21, "CategorizationSection",ExpressionUUID->"d332b0f7-fc1c-44fc-9e80-0bd4822ac2d4",
+Cell[46021, 1051, 484, 13, 21, "CategorizationSection",ExpressionUUID->"d332b0f7-fc1c-44fc-9e80-0bd4822ac2d4",
  CellID->307398791],
-Cell[46037, 1055, 134, 2, 35, "Categorization",ExpressionUUID->"16fb5de0-ad25-43fe-a748-89aab8ff7931",
+Cell[46508, 1066, 134, 2, 35, "Categorization",ExpressionUUID->"16fb5de0-ad25-43fe-a748-89aab8ff7931",
  CellID->953944074],
-Cell[46174, 1059, 138, 2, 35, "Categorization",ExpressionUUID->"dc6b0240-91f3-4ea1-bdf3-bef210ba0b43",
+Cell[46645, 1070, 138, 2, 35, "Categorization",ExpressionUUID->"dc6b0240-91f3-4ea1-bdf3-bef210ba0b43",
  CellID->27867174],
-Cell[46315, 1063, 134, 2, 35, "Categorization",ExpressionUUID->"7d21f27b-dd12-4dd9-b22a-c81b98146c83",
+Cell[46786, 1074, 134, 2, 35, "Categorization",ExpressionUUID->"7d21f27b-dd12-4dd9-b22a-c81b98146c83",
  CellID->3496275],
-Cell[46452, 1067, 143, 2, 35, "Categorization",ExpressionUUID->"98cf2e22-7e5f-4a78-995f-fd5c9fc6810c",
+Cell[46923, 1078, 143, 2, 35, "Categorization",ExpressionUUID->"98cf2e22-7e5f-4a78-995f-fd5c9fc6810c",
  CellID->256246382]
 }, Closed]],
 Cell[CellGroupData[{
-Cell[46632, 1074, 110, 1, 21, "KeywordsSection",ExpressionUUID->"59dd6c04-adc1-4868-8a40-dd3d030c51cc",
+Cell[47103, 1085, 110, 1, 21, "KeywordsSection",ExpressionUUID->"59dd6c04-adc1-4868-8a40-dd3d030c51cc",
  CellID->236657944],
-Cell[46745, 1077, 176, 2, 21, "Keywords",ExpressionUUID->"4898afba-7a0a-439f-8c7e-4f2afbf71b45",
+Cell[47216, 1088, 176, 2, 21, "Keywords",ExpressionUUID->"4898afba-7a0a-439f-8c7e-4f2afbf71b45",
  CellID->268521556],
-Cell[46924, 1081, 172, 2, 21, "Keywords",ExpressionUUID->"7a2d3559-42c8-419b-9078-a8410ba88a0e",
+Cell[47395, 1092, 172, 2, 21, "Keywords",ExpressionUUID->"7a2d3559-42c8-419b-9078-a8410ba88a0e",
  CellID->413381409],
-Cell[47099, 1085, 174, 2, 21, "Keywords",ExpressionUUID->"0a529c1f-dd15-43c0-acd9-921581bc5351",
+Cell[47570, 1096, 174, 2, 21, "Keywords",ExpressionUUID->"0a529c1f-dd15-43c0-acd9-921581bc5351",
  CellID->79312569],
-Cell[47276, 1089, 223, 3, 21, "Keywords",ExpressionUUID->"01530d82-d28b-42aa-b478-2d8ee84629a6",
+Cell[47747, 1100, 221, 3, 21, "Keywords",ExpressionUUID->"01530d82-d28b-42aa-b478-2d8ee84629a6",
  CellID->681729142],
-Cell[47502, 1094, 229, 3, 21, "Keywords",ExpressionUUID->"06be9e8a-cf05-4038-98d0-7b72ac422e54",
+Cell[47971, 1105, 227, 3, 21, "Keywords",ExpressionUUID->"06be9e8a-cf05-4038-98d0-7b72ac422e54",
  CellID->56991772],
-Cell[47734, 1099, 226, 3, 21, "Keywords",ExpressionUUID->"a1a7decc-3a74-45b0-b6c5-e3ff0c3fb919",
+Cell[48201, 1110, 224, 3, 21, "Keywords",ExpressionUUID->"a1a7decc-3a74-45b0-b6c5-e3ff0c3fb919",
  CellID->475629817],
-Cell[47963, 1104, 222, 3, 21, "Keywords",ExpressionUUID->"048092d7-b6c5-4ec8-affd-091f8091ad1f",
+Cell[48428, 1115, 220, 3, 21, "Keywords",ExpressionUUID->"048092d7-b6c5-4ec8-affd-091f8091ad1f",
  CellID->286615801],
-Cell[48188, 1109, 222, 3, 21, "Keywords",ExpressionUUID->"d78d3dfe-bd5d-405c-8bd5-97d99912e691",
+Cell[48651, 1120, 222, 3, 21, "Keywords",ExpressionUUID->"d78d3dfe-bd5d-405c-8bd5-97d99912e691",
  CellID->804040460]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[48447, 1117, 118, 1, 31, "TemplatesSection",ExpressionUUID->"d186b87b-d845-4f2a-bc37-a64b31f19371",
+Cell[48910, 1128, 118, 1, 31, "TemplatesSection",ExpressionUUID->"d186b87b-d845-4f2a-bc37-a64b31f19371",
  CellID->57652393],
-Cell[48568, 1120, 146, 2, 70, "Template",ExpressionUUID->"b31a64d3-93c2-407e-825e-f3a4f7d73567",
+Cell[49031, 1131, 146, 2, 70, "Template",ExpressionUUID->"b31a64d3-93c2-407e-825e-f3a4f7d73567",
  CellID->2821985],
-Cell[48717, 1124, 136, 2, 70, "Template",ExpressionUUID->"7f484aad-9ed1-4122-bc9f-32df63fa4396",
+Cell[49180, 1135, 136, 2, 70, "Template",ExpressionUUID->"7f484aad-9ed1-4122-bc9f-32df63fa4396",
  CellID->99364110],
-Cell[48856, 1128, 135, 2, 70, "Template",ExpressionUUID->"6fedb81c-a693-42aa-b450-f8e4e53c794f",
+Cell[49319, 1139, 135, 2, 70, "Template",ExpressionUUID->"6fedb81c-a693-42aa-b450-f8e4e53c794f",
  CellID->104159675],
-Cell[48994, 1132, 136, 2, 70, "Template",ExpressionUUID->"18df4740-df51-463c-bed1-40255ddd318b",
+Cell[49457, 1143, 136, 2, 70, "Template",ExpressionUUID->"18df4740-df51-463c-bed1-40255ddd318b",
  CellID->37988176]
 }, Closed]]
 }, Open  ]]

--- a/wrappers/Mathematica/RefpropLink/Documentation/English/Tutorials/RefpropLinkInstallation.nb
+++ b/wrappers/Mathematica/RefpropLink/Documentation/English/Tutorials/RefpropLinkInstallation.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     37831,        917]
-NotebookOptionsPosition[     27657,        700]
-NotebookOutlinePosition[     28576,        726]
-CellTagsIndexPosition[     28533,        723]
+NotebookDataLength[     39812,        972]
+NotebookOptionsPosition[     29299,        749]
+NotebookOutlinePosition[     30216,        775]
+CellTagsIndexPosition[     30173,        772]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -29,8 +29,8 @@ have RefpropLink installed.  However, this Tech Note is provided here for \
 completeness of documentation and so that the commands below can be used in \
 other notebooks.\
 \>", "Text",
- CellChangeTimes->{{3.8856370688537383`*^9, 3.8856371539182825`*^9}, {
-  3.885768444034345*^9, 3.8857684899290953`*^9}},
+ CellChangeTimes->{{3.885637068853739*^9, 3.885637153918282*^9}, {
+  3.885768444034345*^9, 3.885768489929095*^9}},
  CellID->411374971,ExpressionUUID->"d66b4e46-a6dc-4945-9891-d313b932b8d7"],
 
 Cell[CellGroupData[{
@@ -47,9 +47,9 @@ documentation that integrates into the Wolfram Documentation Center.\
 \>", "Text",
  CellChangeTimes->{{3.885637606797846*^9, 3.88563787888593*^9}, {
   3.8856526979979887`*^9, 3.8856527023108764`*^9}, {3.8860578740769997`*^9, 
-  3.886057877597709*^9}, {3.8860579180337553`*^9, 3.886057943330084*^9}, {
-  3.886057987386846*^9, 3.8860580000741653`*^9}, {3.886058046050105*^9, 
-  3.8860580827458735`*^9}},
+  3.886057877597709*^9}, {3.886057918033755*^9, 3.886057943330084*^9}, {
+  3.886057987386846*^9, 3.8860580000741644`*^9}, {3.886058046050105*^9, 
+  3.886058082745873*^9}},
  CellID->370723392,ExpressionUUID->"72a0b1e3-a94a-4b89-96c5-9b8972493907"],
 
 Cell[TextData[{
@@ -63,7 +63,7 @@ RefpropLink wrapper for NIST REFPROP."
 }], "Text",
  CellChangeTimes->{{3.885637606797846*^9, 3.88563787888593*^9}, {
   3.8856526979979887`*^9, 3.8856527023108764`*^9}, {3.8860578740769997`*^9, 
-  3.88605788075504*^9}, {3.8860581006750712`*^9, 3.88605810569125*^9}},
+  3.88605788075504*^9}, {3.8860581006750703`*^9, 3.88605810569125*^9}},
  CellID->276814643,ExpressionUUID->"2d64a8cc-28fc-4471-8b6c-f379e79b5a9c"],
 
 Cell[TextData[{
@@ -71,12 +71,62 @@ Cell[TextData[{
   FontWeight->"Bold"],
  " (version 9.1 or 10+) must be installed on the machine.  RefpropLink only \
 provides wrapper functions that make direct calls to the NIST REFPROP DLLs.  \
-For greater functionality, REFPROP 10 or higher is recommended."
+For greater functionality, REFPROP 10 or higher is recommended.  REFPROP must \
+be either:"
 }], "Text",
  CellDingbat->"\\[FilledSquare]",
  CellMargins->{{45, 27}, {4, 4}},
- CellChangeTimes->{{3.885637606797846*^9, 3.8856379699848757`*^9}},
+ CellChangeTimes->{{3.885637606797846*^9, 3.8856379699848757`*^9}, {
+  3.9203273391649075`*^9, 3.920327351045767*^9}},
  CellID->309714428,ExpressionUUID->"f30e73dd-7aa7-4806-8e81-e509179f64f9"],
+
+Cell["\<\
+Installed in the default location (C:\\Program Files(x86)\\REFPROP, or\
+\>", "Item",
+ CellDingbat->"\[FilledSquare]",
+ CellMargins->{{65, Inherited}, {Inherited, Inherited}},
+ CellFrameMargins->8,
+ CellFrameLabelMargins->6,
+ CellChangeTimes->{{3.8857668074893646`*^9, 3.885766824592492*^9}, {
+  3.8857669095835485`*^9, 3.885766948847672*^9}, {3.9203277005215607`*^9, 
+  3.9203277351712265`*^9}, {3.920327787275593*^9, 3.9203277875406857`*^9}},
+ FontSize->12,
+ CellID->567271123,ExpressionUUID->"827c5cd4-d90e-3149-b35b-230f617cc309"],
+
+Cell[TextData[{
+ "Installed in a non-default location indicated by the environment variable, ",
+ StyleBox["RPprefix",
+  FontWeight->"Bold"],
+ ", or"
+}], "Item",
+ CellDingbat->"\[FilledSquare]",
+ CellMargins->{{65, Inherited}, {Inherited, Inherited}},
+ CellFrameMargins->8,
+ CellFrameLabelMargins->6,
+ CellChangeTimes->{{3.8857668074893646`*^9, 3.885766824592492*^9}, {
+  3.8857669095835485`*^9, 3.885766948847672*^9}, {3.920327753074772*^9, 
+  3.9203278254833603`*^9}},
+ FontSize->12,
+ CellID->41218240,ExpressionUUID->"2ca76dea-5716-5249-bf3a-8b2f42bb498b"],
+
+Cell[TextData[{
+ "At a saved location using ",
+ StyleBox["SetDLL[",
+  FontWeight->"Bold"],
+ "1",
+ StyleBox["]",
+  FontWeight->"Bold"],
+ " to browse to the appropriate file path."
+}], "Item",
+ CellDingbat->"\[FilledSquare]",
+ CellMargins->{{65, Inherited}, {Inherited, Inherited}},
+ CellFrameMargins->8,
+ CellFrameLabelMargins->6,
+ CellChangeTimes->{{3.8857668074893646`*^9, 3.885766824592492*^9}, {
+  3.8857669095835485`*^9, 3.885766948847672*^9}, {3.9203278460590477`*^9, 
+  3.9203278897004776`*^9}, {3.920327938195574*^9, 3.9203279647878647`*^9}},
+ FontSize->12,
+ CellID->123337181,ExpressionUUID->"822b8400-4eee-fd49-9d89-97348d342b54"],
 
 Cell[TextData[{
  StyleBox["Mathematica 13.x",
@@ -95,7 +145,7 @@ the Wolfram Documentation Center standards."
  CellDingbat->"\\[FilledSquare]",
  CellMargins->{{45, 27}, {4, 4}},
  CellChangeTimes->{{3.885637606797846*^9, 3.8856381058246164`*^9}, {
-  3.8857685193212457`*^9, 3.8857685193861313`*^9}},
+  3.885768519321245*^9, 3.8857685193861313`*^9}},
  CellID->14947450,ExpressionUUID->"029ad3da-981a-4078-bb21-d5135f44d135"],
 
 Cell[TextData[{
@@ -113,7 +163,7 @@ version 13 and will not be available in earlier versions of Mathematica."
  CellMargins->{{45, 27}, {4, 4}},
  CellChangeTimes->{{3.885637606797846*^9, 3.8856381058246164`*^9}, {
   3.885649448789832*^9, 3.885649546229453*^9}, {3.885649693342385*^9, 
-  3.8856497096972413`*^9}, {3.8857685880421815`*^9, 3.885768644306222*^9}},
+  3.885649709697241*^9}, {3.8857685880421815`*^9, 3.885768644306222*^9}},
  CellID->196003392,ExpressionUUID->"a3511682-abb9-4e15-bfb7-7106463cf6f0"],
 
 Cell["\<\
@@ -122,7 +172,7 @@ Mathematica installation.  The first is building the files in Mathematica \
 13.x or later, directly from a downloaded GitHub repository. \
 \>", "Text",
  CellChangeTimes->{{3.885649584377914*^9, 3.8856496296013923`*^9}, {
-  3.8857366714200425`*^9, 3.8857367225641856`*^9}},
+  3.885736671420043*^9, 3.8857367225641856`*^9}},
  CellID->335940601,ExpressionUUID->"fe13999e-150f-431b-b5be-43c8e601f4de"]
 }, Open  ]],
 
@@ -131,9 +181,9 @@ Cell[CellGroupData[{
 Cell["Build From GitHub Files", "Section",
  CellFrame->{{0, 0}, {0, 3}},
  CellFrameColor->GrayLevel[0.75],
- CellChangeTimes->{{3.8856499816830187`*^9, 3.8856499844957848`*^9}, {
-  3.8856502353619647`*^9, 3.8856502584583993`*^9}, {3.8856503071763887`*^9, 
-  3.8856503177940755`*^9}, {3.8856504124425097`*^9, 3.8856504142138658`*^9}},
+ CellChangeTimes->{{3.885649981683018*^9, 3.885649984495784*^9}, {
+  3.8856502353619647`*^9, 3.8856502584584*^9}, {3.8856503071763887`*^9, 
+  3.885650317794075*^9}, {3.8856504124425097`*^9, 3.885650414213865*^9}},
  CellID->19529436,ExpressionUUID->"a0ed58ea-3875-4a6f-97a3-4693d02c5ec3"],
 
 Cell["\<\
@@ -142,7 +192,7 @@ form the GitHub repository files.  Once this procedure is complete, you will \
 have a build directory containing\
 \>", "Text",
  CellChangeTimes->{{3.8856502676110115`*^9, 3.885650286313549*^9}, {
-  3.885650326564878*^9, 3.8856503918512497`*^9}, {3.885736760124552*^9, 
+  3.885650326564878*^9, 3.885650391851249*^9}, {3.885736760124552*^9, 
   3.885736799564296*^9}, {3.885766497496147*^9, 3.88576652554506*^9}},
  CellID->30415973,ExpressionUUID->"7605449f-8ea4-40f8-863a-4c0fbaaa6960"],
 
@@ -151,8 +201,8 @@ Copies of in-use paclet files and documentation files converted for use in \
 the Documentation Center \
 \>", "ItemNumbered",
  CellChangeTimes->{{3.885741517242681*^9, 3.885741522152186*^9}, {
-  3.8857664394801617`*^9, 3.8857664910155077`*^9}, {3.885766539936263*^9, 
-  3.8857665442882147`*^9}, {3.8857666378396435`*^9, 3.8857667049843817`*^9}},
+  3.885766439480161*^9, 3.8857664910155077`*^9}, {3.885766539936263*^9, 
+  3.8857665442882147`*^9}, {3.885766637839643*^9, 3.8857667049843817`*^9}},
  FontSize->12,
  CellID->342434010,ExpressionUUID->"c3f6ff58-47b0-4372-bc74-a2b89cc6d028"],
 
@@ -161,7 +211,7 @@ A paclet file (RefpropLink-x.x.x.paclet) that can be used to:\
 \>", "ItemNumbered",
  CellChangeTimes->{{3.8857415277134075`*^9, 3.885741530008906*^9}, {
    3.8857415633207474`*^9, 3.8857415656645813`*^9}, 3.8857665315128074`*^9, {
-   3.8857667163603153`*^9, 3.885766795615613*^9}, {3.8857671653204517`*^9, 
+   3.885766716360316*^9, 3.885766795615613*^9}, {3.8857671653204517`*^9, 
    3.8857671753292174`*^9}},
  FontSize->12,
  CellID->253188192,ExpressionUUID->"08a95ce1-c5a4-4dc3-8714-7cc9d5885678"],
@@ -172,7 +222,7 @@ Cell["Install the paclet on the local system,", "Item",
  CellFrameMargins->8,
  CellFrameLabelMargins->6,
  CellChangeTimes->{{3.8857668074893646`*^9, 3.885766824592492*^9}, {
-  3.8857669095835495`*^9, 3.8857669488476715`*^9}},
+  3.8857669095835485`*^9, 3.885766948847672*^9}},
  FontSize->12,
  CellID->333587227,ExpressionUUID->"6f3be817-2138-4a2f-8c6d-4bdffb4aa3e8"],
 
@@ -182,8 +232,8 @@ Cell["Install the paclet on a local paclet repository,", "Item",
  CellFrameMargins->8,
  CellFrameLabelMargins->6,
  CellChangeTimes->{{3.8857668074893646`*^9, 3.885766824592492*^9}, {
-  3.8857669095835495`*^9, 3.8857669488476715`*^9}, {3.8857671262336693`*^9, 
-  3.8857671357448053`*^9}},
+  3.8857669095835485`*^9, 3.885766948847672*^9}, {3.885767126233669*^9, 
+  3.885767135744805*^9}},
  FontSize->12,
  CellID->800960609,ExpressionUUID->"0d79ce8f-47c9-4746-91b7-a90af64a6be2"],
 
@@ -193,8 +243,8 @@ Cell["Install the paclet on the Wolfram Paclet Repository,", "Item",
  CellFrameMargins->8,
  CellFrameLabelMargins->6,
  CellChangeTimes->{{3.8857668074893646`*^9, 3.885766824592492*^9}, {
-  3.8857669095835495`*^9, 3.8857669488476715`*^9}, {3.8857671473690853`*^9, 
-  3.8857671543282013`*^9}},
+  3.8857669095835485`*^9, 3.885766948847672*^9}, {3.8857671473690853`*^9, 
+  3.885767154328201*^9}},
  FontSize->12,
  CellID->2483592,ExpressionUUID->"2da18625-0618-4a86-ba05-dc05e0e0e5d6"],
 
@@ -218,7 +268,7 @@ Cell[TextData[{
  ".  Once the .zip file is downloaded, extract it to a convenient location \
 where the paclet and documentation can be built."
 }], "Text",
- CellChangeTimes->{{3.8857673461628537`*^9, 3.8857674782888174`*^9}, {
+ CellChangeTimes->{{3.885767346162854*^9, 3.8857674782888174`*^9}, {
   3.885767618057556*^9, 3.885767635413966*^9}},
  CellID->381043997,ExpressionUUID->"d0b584ed-9414-444c-bbfd-c801ab75ad11"],
 
@@ -231,8 +281,8 @@ cloned recursively to get the external modules as well, but the Mathematica \
 wrapper does not require them.  Get the Clone path from the < > Code dropdown \
 button, making a copy of the HTTPS path.  The use git clone as follows:\
 \>", "Text",
- CellChangeTimes->{{3.8857673461628537`*^9, 3.8857674782888174`*^9}, {
-  3.885767618057556*^9, 3.8857678535373926`*^9}},
+ CellChangeTimes->{{3.885767346162854*^9, 3.8857674782888174`*^9}, {
+  3.885767618057556*^9, 3.885767853537393*^9}},
  CellID->262896202,ExpressionUUID->"2c7d6282-4134-4296-96b7-a7d253243974"],
 
 Cell[BoxData[
@@ -240,7 +290,7 @@ Cell[BoxData[
   "\"\<https://github.com/usnistgov/REFPROP-wrappers.git\>\""}]], "Code",
  Evaluatable->False,
  InitializationCell->False,
- CellChangeTimes->{{3.88576790521096*^9, 3.8857679250486717`*^9}},
+ CellChangeTimes->{{3.88576790521096*^9, 3.8857679250486712`*^9}},
  CellID->77419262,ExpressionUUID->"bd751bf6-8dfd-40ce-81b7-6e6a50558601"]
 }, Open  ]],
 
@@ -251,7 +301,7 @@ Cell[TextData[{
   FontWeight->"Normal"],
  " directory at the current location.  Navigate down to"
 }], "Text",
- CellChangeTimes->{{3.8857679822993393`*^9, 3.8857680442864456`*^9}},
+ CellChangeTimes->{{3.88576798229934*^9, 3.885768044286445*^9}},
  CellID->244754231,ExpressionUUID->"fc8da1ec-85b2-42dd-9621-35012c0eabab"],
 
 Cell[TextData[{
@@ -260,7 +310,7 @@ Cell[TextData[{
   FontFamily->"Courier New",
   FontWeight->"Normal"]
 }], "Text",
- CellChangeTimes->{{3.8857679822993393`*^9, 3.885768041937501*^9}, {
+ CellChangeTimes->{{3.88576798229934*^9, 3.885768041937501*^9}, {
    3.885768078161369*^9, 3.885768100369235*^9}, {3.885768181897463*^9, 
    3.885768185009964*^9}, 3.8857682602972207`*^9},
  CellID->50221343,ExpressionUUID->"8d0aec21-d8fd-4211-8467-590f132fb327"],
@@ -272,8 +322,8 @@ Cell[TextData[{
  " in Mathematica.   Follow the instructions in this file, evaluating the \
 necessary steps, which are outlined below."
 }], "Text",
- CellChangeTimes->{{3.8857682656665573`*^9, 3.8857682819777927`*^9}, {
-  3.885768348977965*^9, 3.8857683995058146`*^9}},
+ CellChangeTimes->{{3.885768265666558*^9, 3.885768281977793*^9}, {
+  3.885768348977965*^9, 3.885768399505814*^9}},
  CellID->695350250,ExpressionUUID->"238acb32-2793-4272-ac3f-ebbb07f39620"]
 }, Open  ]],
 
@@ -289,18 +339,18 @@ Cell["\<\
 Clear the environment with Quit[] and load Paclet Tools (evaluate one at a \
 time).\
 \>", "MathCaption",
- CellChangeTimes->{{3.8857715647893677`*^9, 3.8857716164289093`*^9}, {
+ CellChangeTimes->{{3.885771564789368*^9, 3.8857716164289093`*^9}, {
   3.885771659116816*^9, 3.885771666205085*^9}},
  CellID->117239214,ExpressionUUID->"57de9371-1a8a-474a-8dce-0a3baf2ecc6f"],
 
 Cell[BoxData[
  RowBox[{"Quit", "[", "]"}]], "Input",
- CellChangeTimes->{{3.8857715800693583`*^9, 3.8857715833733835`*^9}},
+ CellChangeTimes->{{3.885771580069359*^9, 3.8857715833733835`*^9}},
  CellID->248889915,ExpressionUUID->"62d18349-ff84-4337-8634-e481bdb13e14"],
 
 Cell[BoxData[
  RowBox[{"Needs", "[", "\"\<PacletTools`\>\"", "]"}]], "Input",
- CellChangeTimes->{{3.885771641248881*^9, 3.8857716551820793`*^9}},
+ CellChangeTimes->{{3.885771641248881*^9, 3.88577165518208*^9}},
  CellID->396347447,ExpressionUUID->"495dc7af-d537-44e5-93d2-8eef3331429d"]
 }, Open  ]]
 }, Open  ]],
@@ -308,26 +358,26 @@ Cell[BoxData[
 Cell[CellGroupData[{
 
 Cell["Uninstall Existing Versions of RefpropLink", "Subsection",
- CellChangeTimes->{{3.8857201646938486`*^9, 3.8857201684689617`*^9}, {
+ CellChangeTimes->{{3.885720164693848*^9, 3.885720168468962*^9}, {
   3.885771875605647*^9, 3.8857718983252487`*^9}},
  CellID->36980612,ExpressionUUID->"cc4e8347-4384-4c61-9f09-99054f63f433"],
 
 Cell[CellGroupData[{
 
 Cell["Is the \"RefpropLink\" paclet found locally?", "MathCaption",
- CellChangeTimes->{{3.88577172881318*^9, 3.8857717445573273`*^9}},
+ CellChangeTimes->{{3.88577172881318*^9, 3.885771744557328*^9}},
  CellID->116431477,ExpressionUUID->"293a20df-d2ef-4746-922c-1292dc78f24b"],
 
 Cell[BoxData[
  RowBox[{"PacletFind", "[", "\"\<RefpropLink\>\"", "]"}]], "Input",
- CellChangeTimes->{{3.8857717487089915`*^9, 3.8857717602854385`*^9}},
+ CellChangeTimes->{{3.885771748708992*^9, 3.885771760285439*^9}},
  CellID->474689001,ExpressionUUID->"98d9aeb2-d4f9-45fc-9cde-5233dc67e1d6"]
 }, Open  ]],
 
 Cell[CellGroupData[{
 
 Cell["If it is, uninstall any \"RefpropLink\" paclets", "MathCaption",
- CellChangeTimes->{{3.885771823076267*^9, 3.8857718345574265`*^9}, {
+ CellChangeTimes->{{3.885771823076267*^9, 3.885771834557427*^9}, {
   3.8857719141973476`*^9, 3.885771920333706*^9}},
  CellID->689722793,ExpressionUUID->"5c5c446f-f9c2-4745-8440-3728c53e54cd"],
 
@@ -341,7 +391,7 @@ Cell[BoxData[
 Cell[CellGroupData[{
 
 Cell["Building the Documentation", "Subsection",
- CellChangeTimes->{{3.8857201646938486`*^9, 3.8857201684689617`*^9}},
+ CellChangeTimes->{{3.885720164693848*^9, 3.885720168468962*^9}},
  CellID->654739400,ExpressionUUID->"cea2b1eb-146c-47ed-bfb0-ea40e9782cd8"],
 
 Cell["\<\
@@ -356,13 +406,13 @@ Cell[CellGroupData[{
 Cell["Paclet documentation can be built using the single command:", \
 "MathCaption",
  CellChangeTimes->{
-  3.885771969018359*^9, {3.885772124020559*^9, 3.8857721256049004`*^9}},
+  3.885771969018359*^9, {3.885772124020559*^9, 3.8857721256049*^9}},
  CellID->217735914,ExpressionUUID->"81390224-5b15-4c24-a52b-6afbd54d6023"],
 
 Cell[BoxData[
  RowBox[{"PacletDocumentationBuild", "[", 
   RowBox[{"NotebookDirectory", "[", "]"}], "]"}]], "Input",
- CellChangeTimes->{{3.8857720004294086`*^9, 3.885772013958433*^9}},
+ CellChangeTimes->{{3.885772000429408*^9, 3.885772013958433*^9}},
  CellID->50041876,ExpressionUUID->"28473a52-0d0c-426e-a5cd-e9b6f2919e0a"]
 }, Open  ]],
 
@@ -370,7 +420,7 @@ Cell["\<\
 Total time to build the documentation for RefpropLink should be a little over \
 2 minutes.\
 \>", "Text",
- CellChangeTimes->{3.8857720350772643`*^9},
+ CellChangeTimes->{3.885772035077264*^9},
  CellID->60264828,ExpressionUUID->"257f4005-3267-4bfd-a2ba-55aa05ad8443"],
 
 Cell["\<\
@@ -378,14 +428,14 @@ The documentation files are now converted to \"in-product\" format in the new \
 build subdirectory (RefpropLink\\Build) and ready to be integrated into the \
 RefpropLink paclet file for installation.\
 \>", "Text",
- CellChangeTimes->{{3.8857720350772643`*^9, 3.885772066525461*^9}},
+ CellChangeTimes->{{3.885772035077264*^9, 3.885772066525461*^9}},
  CellID->84014794,ExpressionUUID->"e3b59051-50cf-437c-994a-dbb9d8f18ad5"]
 }, Open  ]],
 
 Cell[CellGroupData[{
 
 Cell["Building the Paclet (.paclet) File", "Subsection",
- CellChangeTimes->{{3.8857201761089563`*^9, 3.885720228508751*^9}},
+ CellChangeTimes->{{3.885720176108957*^9, 3.885720228508751*^9}},
  CellID->499018586,ExpressionUUID->"80d2b975-d7bb-425c-8afa-9ff35bf95f74"],
 
 Cell["\<\
@@ -418,7 +468,7 @@ Cell["\<\
 The paclet file (RefpropLink-x.x.x.paclet) will be located in the build \
 directory.\
 \>", "Text",
- CellChangeTimes->{{3.885772229672284*^9, 3.8857722578376637`*^9}},
+ CellChangeTimes->{{3.885772229672284*^9, 3.885772257837664*^9}},
  CellID->23256081,ExpressionUUID->"d8a31354-dd58-4788-850a-9e68bd4c1c15"],
 
 Cell[CellGroupData[{
@@ -427,7 +477,7 @@ Cell["\<\
 Find the path to the latest (.paclet) file in the build directory and use \
 that file to install the paclet.\
 \>", "MathCaption",
- CellChangeTimes->{{3.8857723163015804`*^9, 3.8857723508611765`*^9}},
+ CellChangeTimes->{{3.8857723163015804`*^9, 3.885772350861177*^9}},
  CellID->188614314,ExpressionUUID->"ae1fe757-354a-4eb1-81b8-9356a3744551"],
 
 Cell[BoxData[{
@@ -444,7 +494,7 @@ Cell[BoxData[{
  RowBox[{"PacletInstall", "[", 
   RowBox[{"pFile", ",", 
    RowBox[{"ForceVersionInstall", "->", "True"}]}], "]"}]}], "Input",
- CellChangeTimes->{{3.8857723629250154`*^9, 3.8857723789261384`*^9}},
+ CellChangeTimes->{{3.8857723629250154`*^9, 3.885772378926139*^9}},
  CellID->364051165,ExpressionUUID->"6c5706bf-ad15-4ad5-a830-364953b78bc0"]
 }, Open  ]],
 
@@ -492,12 +542,12 @@ distribution to others.   See the ",
   FontWeight->"Bold"],
  "."
 }], "Text",
- CellChangeTimes->{{3.885650399433389*^9, 3.8856504699741325`*^9}, {
+ CellChangeTimes->{{3.885650399433389*^9, 3.885650469974132*^9}, {
    3.885768717746279*^9, 3.885768742314162*^9}, {3.8860585590425067`*^9, 
-   3.886058599235156*^9}, 3.886058675419272*^9, {3.8860587861187267`*^9, 
-   3.8860588670119367`*^9}, {3.8860590068998084`*^9, 
-   3.8860592279356785`*^9}, {3.8860593417323856`*^9, 
-   3.8860593675325108`*^9}, {3.8860593991564884`*^9, 3.8860594894632173`*^9}},
+   3.886058599235156*^9}, 3.886058675419272*^9, {3.8860587861187263`*^9, 
+   3.886058867011937*^9}, {3.886059006899808*^9, 3.8860592279356785`*^9}, {
+   3.8860593417323856`*^9, 3.886059367532511*^9}, {3.886059399156488*^9, 
+   3.886059489463217*^9}},
  CellID->899396101,ExpressionUUID->"f2939c0e-1305-49c1-8bc2-71daabdd319b"],
 
 Cell[TextData[{
@@ -511,13 +561,12 @@ developed paclets.  RefpropLink has not been placed in the ",
 \"NIST\") and manual updates to the repository when new code updates are \
 made, by potentially many contributors."
 }], "Text",
- CellChangeTimes->{{3.885650399433389*^9, 3.8856504699741325`*^9}, {
+ CellChangeTimes->{{3.885650399433389*^9, 3.885650469974132*^9}, {
    3.885768717746279*^9, 3.885768742314162*^9}, {3.8860585590425067`*^9, 
-   3.886058599235156*^9}, 3.886058675419272*^9, {3.8860587861187267`*^9, 
-   3.8860588670119367`*^9}, {3.8860590068998084`*^9, 
-   3.8860592279356785`*^9}, {3.8860593417323856`*^9, 
-   3.8860593675325108`*^9}, {3.8860593991564884`*^9, 
-   3.8860595607430553`*^9}, {3.8860595971407223`*^9, 3.8860597579487023`*^9}},
+   3.886058599235156*^9}, 3.886058675419272*^9, {3.8860587861187263`*^9, 
+   3.886058867011937*^9}, {3.886059006899808*^9, 3.8860592279356785`*^9}, {
+   3.8860593417323856`*^9, 3.886059367532511*^9}, {3.886059399156488*^9, 
+   3.886059560743055*^9}, {3.8860595971407223`*^9, 3.8860597579487023`*^9}},
  Background->RGBColor[0.87, 0.94, 1],
  CellID->119575501,ExpressionUUID->"7e6fff63-e314-479f-bb00-810386004c0c"],
 
@@ -525,19 +574,19 @@ Cell["\<\
 Once a Paclet Site is set up, or you have access to a remote Paclet Site \
 containing the RefpropLink paclet, \
 \>", "Text",
- CellChangeTimes->{{3.885650399433389*^9, 3.8856504699741325`*^9}, {
+ CellChangeTimes->{{3.885650399433389*^9, 3.885650469974132*^9}, {
    3.885768717746279*^9, 3.885768742314162*^9}, {3.8860585590425067`*^9, 
-   3.886058599235156*^9}, 3.886058675419272*^9, {3.8860587861187267`*^9, 
-   3.8860588670119367`*^9}, {3.8860590068998084`*^9, 3.886059274891367*^9}, {
-   3.886059809404565*^9, 3.8860598228364377`*^9}},
+   3.886058599235156*^9}, 3.886058675419272*^9, {3.8860587861187263`*^9, 
+   3.886058867011937*^9}, {3.886059006899808*^9, 3.886059274891367*^9}, {
+   3.886059809404565*^9, 3.886059822836438*^9}},
  CellID->152816613,ExpressionUUID->"e3b9929a-e4bf-4777-be4a-d06017edbcc4"],
 
 Cell["\<\
 Register the paclet site using PacletSiteRegister (just once on each \
 system/user environment)\
 \>", "Item",
- CellChangeTimes->{{3.8860598954206357`*^9, 3.8860599271960506`*^9}, {
-  3.8860601378441525`*^9, 3.8860601410118904`*^9}, {3.886060195837271*^9, 
+ CellChangeTimes->{{3.886059895420635*^9, 3.88605992719605*^9}, {
+  3.886060137844152*^9, 3.8860601410118904`*^9}, {3.886060195837271*^9, 
   3.8860602075411444`*^9}},
  FontSize->12,
  CellID->258253421,ExpressionUUID->"dd105fa8-d223-4b1f-88c1-0f0f6ff64eea"],
@@ -546,16 +595,16 @@ Cell["\<\
 Update paclet availability on the paclet site using PacletSiteUpdate (in case \
 new paclets/versions have been added)\
 \>", "Item",
- CellChangeTimes->{{3.8860598954206357`*^9, 3.8860599271960506`*^9}, {
-  3.8860601378441525`*^9, 3.886060267972994*^9}},
+ CellChangeTimes->{{3.886059895420635*^9, 3.88605992719605*^9}, {
+  3.886060137844152*^9, 3.886060267972994*^9}},
  FontSize->12,
  CellID->80312916,ExpressionUUID->"32e8c2d6-b8cf-491c-ac0d-0c4e4e5af6bb"],
 
 Cell["\<\
 Use PacletFindRemote to view the available paclets on the paclet site.\
 \>", "Item",
- CellChangeTimes->{{3.8860598954206357`*^9, 3.8860599271960506`*^9}, {
-  3.8860601378441525`*^9, 3.8860601410118904`*^9}, {3.886060281772317*^9, 
+ CellChangeTimes->{{3.886059895420635*^9, 3.88605992719605*^9}, {
+  3.886060137844152*^9, 3.8860601410118904`*^9}, {3.886060281772317*^9, 
   3.8860603127813845`*^9}},
  FontSize->12,
  CellID->240987158,ExpressionUUID->"62ec13d1-4066-4044-a36f-7423fabfad12"],
@@ -564,8 +613,8 @@ Cell["\<\
 Install or update the desired paclet version using PacletInstall from the \
 registered paclet site.\
 \>", "Item",
- CellChangeTimes->{{3.8860598954206357`*^9, 3.8860599271960506`*^9}, {
-  3.8860601378441525`*^9, 3.8860601410118904`*^9}, {3.8860603258282347`*^9, 
+ CellChangeTimes->{{3.886059895420635*^9, 3.88605992719605*^9}, {
+  3.886060137844152*^9, 3.8860601410118904`*^9}, {3.886060325828234*^9, 
   3.886060392981214*^9}},
  FontSize->12,
  CellID->182671851,ExpressionUUID->"d08ca891-535a-4ac4-9c77-92473ec728cd"],
@@ -584,7 +633,7 @@ Cell[TextData[{
  "."
 }], "Text",
  CellChangeTimes->{{3.886060511464193*^9, 3.886060550005167*^9}, 
-   3.8860606642897587`*^9, {3.8860607035589046`*^9, 3.886060703560869*^9}, 
+   3.886060664289758*^9, {3.886060703558904*^9, 3.886060703560869*^9}, 
    3.886060738897913*^9},
  CellID->953165569,ExpressionUUID->"7f40fdea-fbef-4fc7-a2ec-a7a19f0cd158"]
 }, Open  ]],
@@ -602,13 +651,13 @@ Cell[TextData[Cell[BoxData[
    "paclet:RefpropLink/guide/RefpropLink"]], \
 "InlineFormula",ExpressionUUID->"fa8c2076-65d5-4957-8d49-89c0fdb5b5d6"]], \
 "TutorialMoreAbout",
- CellChangeTimes->{{3.88563685755659*^9, 3.8856368678798656`*^9}},
+ CellChangeTimes->{{3.88563685755659*^9, 3.885636867879865*^9}},
  CellID->118998663,ExpressionUUID->"1e98ef8b-c8f9-42e2-8b69-7caa1f2ddbae"],
 
 Cell[TextData[ButtonBox["Paclets",
  BaseStyle->"Link",
  ButtonData->"paclet:guide/Paclets"]], "TutorialMoreAbout",
- CellChangeTimes->{{3.886060846363962*^9, 3.8860608906367874`*^9}},
+ CellChangeTimes->{{3.886060846363962*^9, 3.886060890636787*^9}},
  CellID->663590259,ExpressionUUID->"40e2c6af-3a93-4f0b-8cbd-fd35f0be435e"]
 }, Open  ]],
 
@@ -693,13 +742,13 @@ Cell["NIST REFPROP", "Keywords",
 
 Cell["Properties", "Keywords",
  CellChangeTimes->{{3.8851356717557344`*^9, 3.885135693460149*^9}, {
-  3.8851364891166363`*^9, 3.8851364912063107`*^9}},
+  3.8851364891166368`*^9, 3.885136491206311*^9}},
  CellID->475629817,ExpressionUUID->"3cf0b6d3-c5d8-48e5-b9e8-385e872116f6"]
 }, Open  ]]
 }, Open  ]]
 },
 WindowSize->{700.5, 765.75},
-WindowMargins->{{107.25, Automatic}, {Automatic, 1.5}},
+WindowMargins->{{-823.5, Automatic}, {Automatic, 0}},
 TaggingRules->{
  "DocuToolsSettings" -> {
    "$ApplicationName" -> "RefpropLink", "$LinkBase" -> "RefpropLink", 
@@ -709,7 +758,7 @@ Documentation\\English\\", "$ApplicationDirectory" ->
     "C:\\Users\\jeffp\\eclipse-workspace\\RefpropLink\\RefpropLink"}, 
   "WelcomeScreenSettings" -> {"FEStarting" -> False}, "Paclet" -> 
   "RefpropLink"},
-FrontEndVersion->"13.2 for Microsoft Windows (64-bit) (November 18, 2022)",
+FrontEndVersion->"14.0 for Microsoft Windows (64-bit) (December 12, 2023)",
 StyleDefinitions->FrontEnd`FileName[{"Wolfram"}, "TechNotePageStylesExt.nb", 
   CharacterEncoding -> "UTF-8"],
 ExpressionUUID->"7f07ec48-441c-4b61-9ca6-a8b193dd8e8f"
@@ -728,194 +777,200 @@ Notebook[{
 Cell[CellGroupData[{
 Cell[580, 22, 115, 1, 114, "Title",ExpressionUUID->"4a8d10c4-affd-49ed-b2c5-a08c38b5233f",
  CellID->21507785],
-Cell[698, 25, 470, 8, 63, "Text",ExpressionUUID->"d66b4e46-a6dc-4945-9891-d313b932b8d7",
+Cell[698, 25, 464, 8, 63, "Text",ExpressionUUID->"d66b4e46-a6dc-4945-9891-d313b932b8d7",
  CellID->411374971],
 Cell[CellGroupData[{
-Cell[1193, 37, 173, 2, 45, "Section",ExpressionUUID->"7443aa81-a7ce-4971-88f1-35b3eadf43ea",
+Cell[1187, 37, 173, 2, 45, "Section",ExpressionUUID->"7443aa81-a7ce-4971-88f1-35b3eadf43ea",
  CellID->87861],
-Cell[1369, 41, 708, 11, 63, "Text",ExpressionUUID->"72a0b1e3-a94a-4b89-96c5-9b8972493907",
+Cell[1363, 41, 704, 11, 63, "Text",ExpressionUUID->"72a0b1e3-a94a-4b89-96c5-9b8972493907",
  CellID->370723392],
-Cell[2080, 54, 650, 12, 63, "Text",ExpressionUUID->"2d64a8cc-28fc-4471-8b6c-f379e79b5a9c",
+Cell[2070, 54, 650, 12, 63, "Text",ExpressionUUID->"2d64a8cc-28fc-4471-8b6c-f379e79b5a9c",
  CellID->276814643],
-Cell[2733, 68, 509, 10, 63, "Text",ExpressionUUID->"f30e73dd-7aa7-4806-8e81-e509179f64f9",
+Cell[2723, 68, 587, 12, 63, "Text",ExpressionUUID->"f30e73dd-7aa7-4806-8e81-e509179f64f9",
  CellID->309714428],
-Cell[3245, 80, 705, 18, 63, "Text",ExpressionUUID->"029ad3da-981a-4078-bb21-d5135f44d135",
+Cell[3313, 82, 543, 11, 24, "Item",ExpressionUUID->"827c5cd4-d90e-3149-b35b-230f617cc309",
+ CellID->567271123],
+Cell[3859, 95, 558, 14, 24, "Item",ExpressionUUID->"2ca76dea-5716-5249-bf3a-8b2f42bb498b",
+ CellID->41218240],
+Cell[4420, 111, 639, 17, 24, "Item",ExpressionUUID->"822b8400-4eee-fd49-9d89-97348d342b54",
+ CellID->123337181],
+Cell[5062, 130, 703, 18, 63, "Text",ExpressionUUID->"029ad3da-981a-4078-bb21-d5135f44d135",
  CellID->14947450],
-Cell[3953, 100, 835, 16, 82, "Text",ExpressionUUID->"a3511682-abb9-4e15-bfb7-7106463cf6f0",
+Cell[5768, 150, 833, 16, 82, "Text",ExpressionUUID->"a3511682-abb9-4e15-bfb7-7106463cf6f0",
  CellID->196003392],
-Cell[4791, 118, 428, 7, 44, "Text",ExpressionUUID->"fe13999e-150f-431b-b5be-43c8e601f4de",
+Cell[6604, 168, 426, 7, 44, "Text",ExpressionUUID->"fe13999e-150f-431b-b5be-43c8e601f4de",
  CellID->335940601]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[5256, 130, 406, 6, 56, "Section",ExpressionUUID->"a0ed58ea-3875-4a6f-97a3-4693d02c5ec3",
+Cell[7067, 180, 394, 6, 56, "Section",ExpressionUUID->"a0ed58ea-3875-4a6f-97a3-4693d02c5ec3",
  CellID->19529436],
-Cell[5665, 138, 499, 8, 44, "Text",ExpressionUUID->"7605449f-8ea4-40f8-863a-4c0fbaaa6960",
+Cell[7464, 188, 497, 8, 44, "Text",ExpressionUUID->"7605449f-8ea4-40f8-863a-4c0fbaaa6960",
  CellID->30415973],
-Cell[6167, 148, 444, 8, 28, "ItemNumbered",ExpressionUUID->"c3f6ff58-47b0-4372-bc74-a2b89cc6d028",
+Cell[7964, 198, 440, 8, 28, "ItemNumbered",ExpressionUUID->"c3f6ff58-47b0-4372-bc74-a2b89cc6d028",
  CellID->342434010],
-Cell[6614, 158, 435, 8, 28, "ItemNumbered",ExpressionUUID->"08a95ce1-c5a4-4dc3-8714-7cc9d5885678",
+Cell[8407, 208, 433, 8, 28, "ItemNumbered",ExpressionUUID->"08a95ce1-c5a4-4dc3-8714-7cc9d5885678",
  CellID->253188192],
-Cell[7052, 168, 405, 8, 24, "Item",ExpressionUUID->"6f3be817-2138-4a2f-8c6d-4bdffb4aa3e8",
+Cell[8843, 218, 403, 8, 24, "Item",ExpressionUUID->"6f3be817-2138-4a2f-8c6d-4bdffb4aa3e8",
  CellID->333587227],
-Cell[7460, 178, 467, 9, 24, "Item",ExpressionUUID->"0d79ce8f-47c9-4746-91b7-a90af64a6be2",
+Cell[9249, 228, 461, 9, 24, "Item",ExpressionUUID->"0d79ce8f-47c9-4746-91b7-a90af64a6be2",
  CellID->800960609],
-Cell[7930, 189, 469, 9, 24, "Item",ExpressionUUID->"2da18625-0618-4a86-ba05-dc05e0e0e5d6",
+Cell[9713, 239, 465, 9, 24, "Item",ExpressionUUID->"2da18625-0618-4a86-ba05-dc05e0e0e5d6",
  CellID->2483592],
 Cell[CellGroupData[{
-Cell[8424, 202, 195, 2, 42, "Subsection",ExpressionUUID->"fbe1ed0e-d6b4-46fa-b3b6-e5930178f5c6",
+Cell[10203, 252, 195, 2, 42, "Subsection",ExpressionUUID->"fbe1ed0e-d6b4-46fa-b3b6-e5930178f5c6",
  CellID->209726609],
-Cell[8622, 206, 661, 16, 63, "Text",ExpressionUUID->"d0b584ed-9414-444c-bbfd-c801ab75ad11",
+Cell[10401, 256, 659, 16, 63, "Text",ExpressionUUID->"d0b584ed-9414-444c-bbfd-c801ab75ad11",
  CellID->381043997],
 Cell[CellGroupData[{
-Cell[9308, 226, 603, 9, 82, "Text",ExpressionUUID->"2c7d6282-4134-4296-96b7-a7d253243974",
+Cell[11085, 276, 599, 9, 82, "Text",ExpressionUUID->"2c7d6282-4134-4296-96b7-a7d253243974",
  CellID->262896202],
-Cell[9914, 237, 313, 6, 42, "Code",ExpressionUUID->"bd751bf6-8dfd-40ce-81b7-6e6a50558601",
+Cell[11687, 287, 313, 6, 42, "Code",ExpressionUUID->"bd751bf6-8dfd-40ce-81b7-6e6a50558601",
  Evaluatable->False,
  InitializationCell->False,
  CellID->77419262]
 }, Open  ]],
-Cell[10242, 246, 337, 8, 25, "Text",ExpressionUUID->"fc8da1ec-85b2-42dd-9621-35012c0eabab",
+Cell[12015, 296, 332, 8, 25, "Text",ExpressionUUID->"fc8da1ec-85b2-42dd-9621-35012c0eabab",
  CellID->244754231],
-Cell[10582, 256, 419, 9, 25, "Text",ExpressionUUID->"8d0aec21-d8fd-4211-8467-590f132fb327",
+Cell[12350, 306, 416, 9, 25, "Text",ExpressionUUID->"8d0aec21-d8fd-4211-8467-590f132fb327",
  CellID->50221343],
-Cell[11004, 267, 408, 9, 44, "Text",ExpressionUUID->"238acb32-2793-4272-ac3f-ebbb07f39620",
+Cell[12769, 317, 402, 9, 44, "Text",ExpressionUUID->"238acb32-2793-4272-ac3f-ebbb07f39620",
  CellID->695350250]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[11449, 281, 185, 2, 42, "Subsection",ExpressionUUID->"8bfd03c2-ae83-414b-b7f3-4d4d3369af7c",
+Cell[13208, 331, 185, 2, 42, "Subsection",ExpressionUUID->"8bfd03c2-ae83-414b-b7f3-4d4d3369af7c",
  CellID->437052280],
 Cell[CellGroupData[{
-Cell[11659, 287, 308, 6, 40, "MathCaption",ExpressionUUID->"57de9371-1a8a-474a-8dce-0a3baf2ecc6f",
+Cell[13418, 337, 306, 6, 40, "MathCaption",ExpressionUUID->"57de9371-1a8a-474a-8dce-0a3baf2ecc6f",
  CellID->117239214],
-Cell[11970, 295, 197, 3, 25, "Input",ExpressionUUID->"62d18349-ff84-4337-8634-e481bdb13e14",
+Cell[13727, 345, 195, 3, 25, "Input",ExpressionUUID->"62d18349-ff84-4337-8634-e481bdb13e14",
  CellID->248889915],
-Cell[12170, 300, 220, 3, 25, "Input",ExpressionUUID->"495dc7af-d537-44e5-93d2-8eef3331429d",
+Cell[13925, 350, 217, 3, 25, "Input",ExpressionUUID->"495dc7af-d537-44e5-93d2-8eef3331429d",
  CellID->396347447]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[12439, 309, 259, 3, 42, "Subsection",ExpressionUUID->"cc4e8347-4384-4c61-9f09-99054f63f433",
+Cell[14191, 359, 255, 3, 42, "Subsection",ExpressionUUID->"cc4e8347-4384-4c61-9f09-99054f63f433",
  CellID->36980612],
 Cell[CellGroupData[{
-Cell[12723, 316, 209, 2, 40, "MathCaption",ExpressionUUID->"293a20df-d2ef-4746-922c-1292dc78f24b",
+Cell[14471, 366, 207, 2, 40, "MathCaption",ExpressionUUID->"293a20df-d2ef-4746-922c-1292dc78f24b",
  CellID->116431477],
-Cell[12935, 320, 226, 3, 25, "Input",ExpressionUUID->"98d9aeb2-d4f9-45fc-9cde-5233dc67e1d6",
+Cell[14681, 370, 222, 3, 25, "Input",ExpressionUUID->"98d9aeb2-d4f9-45fc-9cde-5233dc67e1d6",
  CellID->474689001]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[13198, 328, 264, 3, 40, "MathCaption",ExpressionUUID->"5c5c446f-f9c2-4745-8440-3728c53e54cd",
+Cell[14940, 378, 262, 3, 40, "MathCaption",ExpressionUUID->"5c5c446f-f9c2-4745-8440-3728c53e54cd",
  CellID->689722793],
-Cell[13465, 333, 226, 3, 25, "Input",ExpressionUUID->"63537482-3317-46bc-b267-e256fc9e351f",
+Cell[15205, 383, 226, 3, 25, "Input",ExpressionUUID->"63537482-3317-46bc-b267-e256fc9e351f",
  CellID->38403515]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[13740, 342, 193, 2, 42, "Subsection",ExpressionUUID->"cea2b1eb-146c-47ed-bfb0-ea40e9782cd8",
+Cell[15480, 392, 189, 2, 42, "Subsection",ExpressionUUID->"cea2b1eb-146c-47ed-bfb0-ea40e9782cd8",
  CellID->654739400],
-Cell[13936, 346, 320, 5, 63, "Text",ExpressionUUID->"9058d057-35f1-459b-9314-68960d4ce915",
+Cell[15672, 396, 320, 5, 63, "Text",ExpressionUUID->"9058d057-35f1-459b-9314-68960d4ce915",
  CellID->361885008],
 Cell[CellGroupData[{
-Cell[14281, 355, 252, 4, 40, "MathCaption",ExpressionUUID->"81390224-5b15-4c24-a52b-6afbd54d6023",
+Cell[16017, 405, 248, 4, 40, "MathCaption",ExpressionUUID->"81390224-5b15-4c24-a52b-6afbd54d6023",
  CellID->217735914],
-Cell[14536, 361, 258, 4, 25, "Input",ExpressionUUID->"28473a52-0d0c-426e-a5cd-e9b6f2919e0a",
+Cell[16268, 411, 256, 4, 25, "Input",ExpressionUUID->"28473a52-0d0c-426e-a5cd-e9b6f2919e0a",
  CellID->50041876]
 }, Open  ]],
-Cell[14809, 368, 232, 5, 25, "Text",ExpressionUUID->"257f4005-3267-4bfd-a2ba-55aa05ad8443",
+Cell[16539, 418, 230, 5, 25, "Text",ExpressionUUID->"257f4005-3267-4bfd-a2ba-55aa05ad8443",
  CellID->60264828],
-Cell[15044, 375, 365, 6, 44, "Text",ExpressionUUID->"e3b59051-50cf-437c-994a-dbb9d8f18ad5",
+Cell[16772, 425, 363, 6, 44, "Text",ExpressionUUID->"e3b59051-50cf-437c-994a-dbb9d8f18ad5",
  CellID->84014794]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[15446, 386, 199, 2, 42, "Subsection",ExpressionUUID->"80d2b975-d7bb-425c-8afa-9ff35bf95f74",
+Cell[17172, 436, 197, 2, 42, "Subsection",ExpressionUUID->"80d2b975-d7bb-425c-8afa-9ff35bf95f74",
  CellID->499018586],
-Cell[15648, 390, 230, 4, 25, "Text",ExpressionUUID->"a14cb0dd-fae4-494f-b2ae-36e318216ea2",
+Cell[17372, 440, 230, 4, 25, "Text",ExpressionUUID->"a14cb0dd-fae4-494f-b2ae-36e318216ea2",
  CellID->35532133],
 Cell[CellGroupData[{
-Cell[15903, 398, 182, 2, 40, "MathCaption",ExpressionUUID->"6dfdf778-3936-4106-bee1-16f71598a406",
+Cell[17627, 448, 182, 2, 40, "MathCaption",ExpressionUUID->"6dfdf778-3936-4106-bee1-16f71598a406",
  CellID->114716107],
-Cell[16088, 402, 247, 4, 25, "Input",ExpressionUUID->"8ef2aa3f-e89e-4e61-b3ca-e9c1edfe14b6",
+Cell[17812, 452, 247, 4, 25, "Input",ExpressionUUID->"8ef2aa3f-e89e-4e61-b3ca-e9c1edfe14b6",
  CellID->57257048]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[16384, 412, 182, 2, 42, "Subsection",ExpressionUUID->"c9fbc6a4-d6d4-402a-b50a-cb91893d7230",
+Cell[18108, 462, 182, 2, 42, "Subsection",ExpressionUUID->"c9fbc6a4-d6d4-402a-b50a-cb91893d7230",
  CellID->328456102],
-Cell[16569, 416, 250, 5, 25, "Text",ExpressionUUID->"d8a31354-dd58-4788-850a-9e68bd4c1c15",
+Cell[18293, 466, 248, 5, 25, "Text",ExpressionUUID->"d8a31354-dd58-4788-850a-9e68bd4c1c15",
  CellID->23256081],
 Cell[CellGroupData[{
-Cell[16844, 425, 284, 5, 57, "MathCaption",ExpressionUUID->"ae1fe757-354a-4eb1-81b8-9356a3744551",
+Cell[18566, 475, 282, 5, 57, "MathCaption",ExpressionUUID->"ae1fe757-354a-4eb1-81b8-9356a3744551",
  CellID->188614314],
-Cell[17131, 432, 636, 15, 43, "Input",ExpressionUUID->"6c5706bf-ad15-4ad5-a830-364953b78bc0",
+Cell[18851, 482, 634, 15, 43, "Input",ExpressionUUID->"6c5706bf-ad15-4ad5-a830-364953b78bc0",
  CellID->364051165]
 }, Open  ]],
-Cell[17782, 450, 355, 6, 44, "Text",ExpressionUUID->"62afa12e-3d33-4685-b58f-245962abc8d0",
+Cell[19500, 500, 355, 6, 44, "Text",ExpressionUUID->"62afa12e-3d33-4685-b58f-245962abc8d0",
  CellID->906285485]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[18186, 462, 320, 5, 56, "Section",ExpressionUUID->"508177de-db60-45e9-8eb4-367ec5dd7b72",
+Cell[19904, 512, 320, 5, 56, "Section",ExpressionUUID->"508177de-db60-45e9-8eb4-367ec5dd7b72",
  CellID->18459449],
-Cell[18509, 469, 1468, 31, 101, "Text",ExpressionUUID->"f2939c0e-1305-49c1-8bc2-71daabdd319b",
+Cell[20227, 519, 1456, 31, 101, "Text",ExpressionUUID->"f2939c0e-1305-49c1-8bc2-71daabdd319b",
  CellID->899396101],
-Cell[19980, 502, 1036, 19, 98, "Text",ExpressionUUID->"7e6fff63-e314-479f-bb00-810386004c0c",
+Cell[21686, 552, 1020, 18, 98, "Text",ExpressionUUID->"7e6fff63-e314-479f-bb00-810386004c0c",
  CellID->119575501],
-Cell[21019, 523, 555, 9, 25, "Text",ExpressionUUID->"e3b9929a-e4bf-4777-be4a-d06017edbcc4",
+Cell[22709, 572, 547, 9, 25, "Text",ExpressionUUID->"e3b9929a-e4bf-4777-be4a-d06017edbcc4",
  CellID->152816613],
-Cell[21577, 534, 383, 8, 24, "Item",ExpressionUUID->"dd105fa8-d223-4b1f-88c1-0f0f6ff64eea",
+Cell[23259, 583, 376, 8, 24, "Item",ExpressionUUID->"dd105fa8-d223-4b1f-88c1-0f0f6ff64eea",
  CellID->258253421],
-Cell[21963, 544, 351, 7, 24, "Item",ExpressionUUID->"32e8c2d6-b8cf-491c-ac0d-0c4e4e5af6bb",
+Cell[23638, 593, 344, 7, 24, "Item",ExpressionUUID->"32e8c2d6-b8cf-491c-ac0d-0c4e4e5af6bb",
  CellID->80312916],
-Cell[22317, 553, 358, 7, 24, "Item",ExpressionUUID->"62ec13d1-4066-4044-a36f-7423fabfad12",
+Cell[23985, 602, 351, 7, 24, "Item",ExpressionUUID->"62ec13d1-4066-4044-a36f-7423fabfad12",
  CellID->240987158],
-Cell[22678, 562, 387, 8, 24, "Item",ExpressionUUID->"d08ca891-535a-4ac4-9c77-92473ec728cd",
+Cell[24339, 611, 378, 8, 24, "Item",ExpressionUUID->"d08ca891-535a-4ac4-9c77-92473ec728cd",
  CellID->182671851],
-Cell[23068, 572, 600, 16, 25, "Text",ExpressionUUID->"7f40fdea-fbef-4fc7-a2ec-a7a19f0cd158",
+Cell[24720, 621, 596, 16, 25, "Text",ExpressionUUID->"7f40fdea-fbef-4fc7-a2ec-a7a19f0cd158",
  CellID->953165569]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[23705, 593, 190, 2, 74, "TutorialMoreAboutSection",ExpressionUUID->"87b5e9d2-9f79-42ad-9836-23038a9bf931",
+Cell[25353, 642, 190, 2, 74, "TutorialMoreAboutSection",ExpressionUUID->"87b5e9d2-9f79-42ad-9836-23038a9bf931",
  CellID->78867934],
-Cell[23898, 597, 375, 8, 27, "TutorialMoreAbout",ExpressionUUID->"1e98ef8b-c8f9-42e2-8b69-7caa1f2ddbae",
+Cell[25546, 646, 373, 8, 27, "TutorialMoreAbout",ExpressionUUID->"1e98ef8b-c8f9-42e2-8b69-7caa1f2ddbae",
  CellID->118998663],
-Cell[24276, 607, 257, 4, 24, "TutorialMoreAbout",ExpressionUUID->"40e2c6af-3a93-4f0b-8cbd-fd35f0be435e",
+Cell[25922, 656, 255, 4, 24, "TutorialMoreAbout",ExpressionUUID->"40e2c6af-3a93-4f0b-8cbd-fd35f0be435e",
  CellID->663590259]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[24570, 616, 128, 1, 74, "RelatedTutorialsSection",ExpressionUUID->"5e00bfb5-85a3-4623-b2c5-0271fbe3bdad",
+Cell[26214, 665, 128, 1, 74, "RelatedTutorialsSection",ExpressionUUID->"5e00bfb5-85a3-4623-b2c5-0271fbe3bdad",
  CellID->655682118],
-Cell[24701, 619, 313, 6, 24, "RelatedTutorials",ExpressionUUID->"2009d84c-abec-41b0-b5c8-0dde8cc058cc",
+Cell[26345, 668, 313, 6, 24, "RelatedTutorials",ExpressionUUID->"2009d84c-abec-41b0-b5c8-0dde8cc058cc",
  CellID->376025285],
-Cell[25017, 627, 268, 4, 24, "RelatedTutorials",ExpressionUUID->"c78d4288-a0de-4964-95aa-6fc8ede08dfb",
+Cell[26661, 676, 268, 4, 24, "RelatedTutorials",ExpressionUUID->"c78d4288-a0de-4964-95aa-6fc8ede08dfb",
  CellID->132182847]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[25334, 637, 110, 1, 72, "MetadataSection",ExpressionUUID->"823b48af-0826-4b91-81f3-ffb461c8d799",
+Cell[26978, 686, 110, 1, 72, "MetadataSection",ExpressionUUID->"823b48af-0826-4b91-81f3-ffb461c8d799",
  CellID->106451810],
-Cell[25447, 640, 541, 12, 26, "History",ExpressionUUID->"d8c0fc73-9ca2-4fec-a1d4-f5318e40e00d",
+Cell[27091, 689, 541, 12, 26, "History",ExpressionUUID->"d8c0fc73-9ca2-4fec-a1d4-f5318e40e00d",
  CellID->365167251],
 Cell[CellGroupData[{
-Cell[26013, 656, 122, 1, 21, "CategorizationSection",ExpressionUUID->"e4e333f1-55fa-46c9-b14a-77c29070dc87",
+Cell[27657, 705, 122, 1, 21, "CategorizationSection",ExpressionUUID->"e4e333f1-55fa-46c9-b14a-77c29070dc87",
  CellID->174385972],
-Cell[26138, 659, 137, 2, 34, "Categorization",ExpressionUUID->"fd5a9991-0a7e-4092-82df-7488b41a54dc",
+Cell[27782, 708, 137, 2, 34, "Categorization",ExpressionUUID->"fd5a9991-0a7e-4092-82df-7488b41a54dc",
  CellID->395971078],
-Cell[26278, 663, 139, 2, 34, "Categorization",ExpressionUUID->"04c19b50-9a84-479e-8106-6cd13ebbe458",
+Cell[27922, 712, 139, 2, 34, "Categorization",ExpressionUUID->"04c19b50-9a84-479e-8106-6cd13ebbe458",
  CellID->505239157],
-Cell[26420, 667, 135, 2, 34, "Categorization",ExpressionUUID->"03730a7d-3e4a-4f28-8b68-ea0ed208778c",
+Cell[28064, 716, 135, 2, 34, "Categorization",ExpressionUUID->"03730a7d-3e4a-4f28-8b68-ea0ed208778c",
  CellID->29117665],
-Cell[26558, 671, 164, 2, 34, "Categorization",ExpressionUUID->"6d6759ec-dcbd-4256-b7a5-46a079a0cbcb",
+Cell[28202, 720, 164, 2, 34, "Categorization",ExpressionUUID->"6d6759ec-dcbd-4256-b7a5-46a079a0cbcb",
  CellID->389130982]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[26759, 678, 110, 1, 31, "KeywordsSection",ExpressionUUID->"88d4e0fc-eb41-45e6-a6d3-d3fb3aca6e86",
+Cell[28403, 727, 110, 1, 31, "KeywordsSection",ExpressionUUID->"88d4e0fc-eb41-45e6-a6d3-d3fb3aca6e86",
  CellID->619312300],
-Cell[26872, 681, 176, 2, 20, "Keywords",ExpressionUUID->"9611116f-5db2-4140-89ae-a6fea9d5e5da",
+Cell[28516, 730, 176, 2, 20, "Keywords",ExpressionUUID->"9611116f-5db2-4140-89ae-a6fea9d5e5da",
  CellID->268521556],
-Cell[27051, 685, 172, 2, 20, "Keywords",ExpressionUUID->"86400e27-815d-4e6f-aa3b-bfd079e93e2c",
+Cell[28695, 734, 172, 2, 20, "Keywords",ExpressionUUID->"86400e27-815d-4e6f-aa3b-bfd079e93e2c",
  CellID->413381409],
-Cell[27226, 689, 174, 2, 20, "Keywords",ExpressionUUID->"7492f500-db1c-4788-b548-dd6a88372759",
+Cell[28870, 738, 174, 2, 20, "Keywords",ExpressionUUID->"7492f500-db1c-4788-b548-dd6a88372759",
  CellID->79312569],
-Cell[27403, 693, 226, 3, 20, "Keywords",ExpressionUUID->"3cf0b6d3-c5d8-48e5-b9e8-385e872116f6",
+Cell[29047, 742, 224, 3, 20, "Keywords",ExpressionUUID->"3cf0b6d3-c5d8-48e5-b9e8-385e872116f6",
  CellID->475629817]
 }, Open  ]]
 }, Open  ]]

--- a/wrappers/Mathematica/RefpropLink/PacletInfo.wl
+++ b/wrappers/Mathematica/RefpropLink/PacletInfo.wl
@@ -3,7 +3,7 @@
 PacletObject[
     <|
         "Name" -> "RefpropLink",
-        "Version" -> "1.1.0",
+        "Version" -> "1.1.1",
         "WolframVersion" -> "13.0+",
         "SystemID" -> {"Windows-x86-64"},
         "Description" -> "Provides wrapper functions for the NIST REFPROP materials library functions.",

--- a/wrappers/Mathematica/RefpropLink/TextResources/Filepaths.txt
+++ b/wrappers/Mathematica/RefpropLink/TextResources/Filepaths.txt
@@ -1,1 +1,1 @@
-C:\Program Files (x86)\REFPROP\REFPRP64.DLL,C:\Program Files (x86)\REFPROP
+default,default


### PR DESCRIPTION
Several changes made to the RefpropLink paclet to better locate NIST REFPROP DLLs when installed in a non-standard location.  Changes in Mathematica paclet structure caused method of storing path locations as resources was failing.

## Changes include:

- Checking for `RPprefix` environment variable first (set by REFPROP installation)
- Fixing `SetDLL[1]` and `SetPath[1]` functions to store alternate locations in paclet resource file using MM13+ paclet structure
- Allowing `SetDLL[-1]` and `SetPath[-1]` to simply return current paths for DLL and Fluids location for debugging purposes
- Fixed output diagnostics to user when REFPROP DLL is not found on loading RefpropLink and provide better instructions on mitigating actions
- Update README and Mathematica documentation pages.
- Update the RefpropLink patch release to 1.1.1

## Testing

- Re-installed REFPROP 10.0 and 10.0.0.2 to non-standard location on separate drive and successfully tested loading of DLL
- Installed REFPROP 9.1 in non-standard location and successfully tested loading of DLL
- Changed location of DLL, both temporarily and permanently, using `SetDLL[]`
- Changed location of FLUIDS/MIXTURES files, both temporarily and permanently, using `SetPath[]`
- Monitored paclet resource file for proper behavior in all of the above tests.

## Additional Information

- Updated documentation notebooks (*.nb files) will be difficult to review without Mathematica as there are many  esoteric Wolfram language changes when small changes are made to the notebooks. 
- Main package `RefpropLink.wl` is python-like and should be easy enough to review
- All testing is complete and ready to merge.

## Related Issues

Fixes #581 