### PR TITLE
Updated TEST.FOR in FORTRAN wrappers 

### DIFF
--- a/wrappers/FORTRAN/shared/TEST.FOR
+++ b/wrappers/FORTRAN/shared/TEST.FOR
@@ -19,7 +19,7 @@ c       uPa-s, W/m-K, N/m
 
 c...Load in the full mixture setup for R407C, as well as the PPF file.
       nc=4
-      hf='R32.FLD|R125.FLD|R125.FLD|R407C.PPF|'
+      hf='R32.FLD|R125.FLD|R134A.FLD|R407C.PPF|'
       hfmix='hmx.bnc'
       hrf='DEF'
       call SETUPdll(nc,hf,hfmix,hrf,ierr,herr)

--- a/wrappers/FORTRAN/shared/TEST.FOR
+++ b/wrappers/FORTRAN/shared/TEST.FOR
@@ -15,14 +15,11 @@ c       uPa-s, W/m-K, N/m
       parameter (ncmax=20)   !max number of components in mixture
       dimension x(ncmax),xliq(ncmax),xvap(ncmax)
       character hrf*3, herr*255
-      character*255 hf(ncmax),hfmix
+      character*255 hf,hfmix
 
 c...Load in the full mixture setup for R407C, as well as the PPF file.
       nc=4
-      hf(1)='R32.FLD'
-      hf(2)='R125.FLD'
-      hf(3)='R134A.FLD'
-      hf(4)='R407C.PPF'
+      hf='R32.FLD|R125.FLD|R125.FLD|R407C.PPF|'
       hfmix='hmx.bnc'
       hrf='DEF'
       call SETUPdll(nc,hf,hfmix,hrf,ierr,herr)


### PR DESCRIPTION
The formal version just can't work on Refprop 9.1 and 10.0. I changed the format of hFiles and it works well.